### PR TITLE
alerts_gcs script accepts GCP credential from a Windmill resource

### DIFF
--- a/f/frizzle/alerts_gcs.py
+++ b/f/frizzle/alerts_gcs.py
@@ -132,8 +132,7 @@ def sync_gcs_to_local(
         the (local) file names that were written.
 
     FIXME: Ensure dst_path exists before downloading files.
-    FIXME: sync, don't brute-force re-download files that already exist
-       - see https://github.com/ConservationMetrics/frizzle-sandbox/issues/169
+    FIXME: sync, don't brute-force re-download files that already exist - see #6
     """
     gcp_credential = Credentials.from_service_account_info(gcp_service_acct)
     storage_client = gcs.Client(

--- a/f/frizzle/alerts_gcs.script.yaml
+++ b/f/frizzle/alerts_gcs.script.yaml
@@ -2,9 +2,7 @@ summary: ''
 description: ''
 lock: '!inline f/frizzle/alerts_gcs.script.lock'
 concurrency_time_window_s: 0
-has_preprocessor: false
 kind: script
-no_main_func: false
 schema:
   $schema: 'https://json-schema.org/draft/2020-12/schema'
   type: object
@@ -36,11 +34,17 @@ schema:
       description: ''
       default: /frizzle-persistent-storage/datalake/change_detection/alerts
       originalType: string
+    gcp_service_acct:
+      type: object
+      description: ''
+      default: null
+      format: resource-gcp_service_account
     territory_id:
       type: integer
       description: ''
       default: null
   required:
+    - gcp_service_acct
     - alerts_bucket
     - territory_id
     - db

--- a/f/frizzle/alerts_gcs.script.yaml
+++ b/f/frizzle/alerts_gcs.script.yaml
@@ -7,12 +7,11 @@ schema:
   $schema: 'https://json-schema.org/draft/2020-12/schema'
   type: object
   order:
-    - no_default
-    - name
-    - age
-    - obj
-    - l
-    - file_
+    - gcp_service_acct
+    - alerts_bucket
+    - territory_id
+    - db
+    - db_table_name
   properties:
     alerts_bucket:
       type: string


### PR DESCRIPTION
With this PR, the alerts_gcs script accepts Google Cloud service account credential from a Windmill resource.

The Windmill resource type is `gcp_service_account`.