### PR TITLE
sharing fixtures across tests

### DIFF
--- a/f/frizzle/kobo/tests/conftest.py
+++ b/f/frizzle/kobo/tests/conftest.py
@@ -2,16 +2,10 @@ import re
 from dataclasses import dataclass
 
 import pytest
-import responses
-import testing.postgresql
 
 from f.frizzle.kobo.tests.assets import server_responses
 
-
-@pytest.fixture
-def mocked_responses():
-    with responses.RequestsMock() as rsps:
-        yield rsps
+pytest_plugins = ["f.frizzle.tests.conftest"]
 
 
 @pytest.fixture
@@ -45,12 +39,3 @@ def koboserver(mocked_responses):
     )
 
     return KoboServer(dict(server_url=server_url, api_key="Callooh!Callay!"), form_id)
-
-
-@pytest.fixture
-def pg_database():
-    db = testing.postgresql.Postgresql(port=7654)
-    dsn = db.dsn()
-    dsn["dbname"] = dsn.pop("database")
-    yield dsn
-    db.stop

--- a/f/frizzle/tests/conftest.py
+++ b/f/frizzle/tests/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+import responses
+import testing.postgresql
+
+
+@pytest.fixture
+def mocked_responses():
+    """responses.RequestsMock context, for testing code that makes HTTP requests."""
+    with responses.RequestsMock() as rsps:
+        yield rsps
+
+
+@pytest.fixture
+def pg_database():
+    """A dsn that may be used to connect to a live (local for test) postgresql server"""
+    db = testing.postgresql.Postgresql(port=7654)
+    dsn = db.dsn()
+    dsn["dbname"] = dsn.pop("database")
+    yield dsn
+    db.stop

--- a/f/frizzle/tests/conftest.py
+++ b/f/frizzle/tests/conftest.py
@@ -1,11 +1,11 @@
 import pytest
-import responses
-import testing.postgresql
 
 
 @pytest.fixture
 def mocked_responses():
     """responses.RequestsMock context, for testing code that makes HTTP requests."""
+    import responses
+
     with responses.RequestsMock() as rsps:
         yield rsps
 
@@ -13,6 +13,8 @@ def mocked_responses():
 @pytest.fixture
 def pg_database():
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
+    import testing.postgresql
+
     db = testing.postgresql.Postgresql(port=7654)
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")


### PR DESCRIPTION
## Goal

Allow sharing pytest fixtures across tests suites, even when each suite runs in different install environments.

## What I changed

Many Frizzle flows follow similar patterns, and therefore use the same pytest fixtures in their test suites.  This PR builds a library of "sharable" fixtures that all suites can avail themselves.  A `*_test.py` file can make this library available by including the line

    pytest_plugins = ["f.frizzle.tests.conftest"]

See https://docs.pytest.org/en/stable/how-to/writing_plugins.html

## Notes for reviewers

This PR may be ill-advised, for up to a few reasons:

0. This is my first use of "pytest plugins" so not sure if I have the mental model correct.
1. It introduces some indirection that I don't love.  `gc-scripts-hub` is already unconventional in that `tox.ini` builds separate environments different test suites, since their dependencies can diverge so much.  Under this PR, one test suite may use the plugin that introduces its own package dependencies but those dependencies are not declared at the shared library (plugin) scope.  Rather the test suite needs to be aware of which shared fixture(s) it uses -- and that fixture's package dependencies -- and declare them in its own `requirements-test.txt`.
2. Probably long term I will have wanted to define these shared fixtures at even a lower scope: e.g. one file per fixture.  And then a specific test file would do something more along the lines of

```
pytest_plugins = ["f.frizzle.tests.plugins.postgresql", "f.frizzle.tests.plugins.mocked_responses"]
```
