### PR TITLE
Bugfix conninfo for postgresql connections

### DIFF
--- a/f/frizzle/alerts/alerts_gcs.py
+++ b/f/frizzle/alerts/alerts_gcs.py
@@ -30,9 +30,10 @@ logger = logging.getLogger(__name__)
 
 def conninfo(db: postgresql):
     """Convert a `postgresql` Windmill Resources to psycopg-style connection string"""
-    return "dbname={dbname} user={user} password={password} host={host} port={port}".format(
-        **db
-    )
+    # password is optional
+    password_part = f" password={db['password']}" if "password" in db else ""
+    conn = "dbname={dbname} user={user} host={host} port={port}".format(**db)
+    return conn + password_part
 
 
 def main(

--- a/f/frizzle/comapeo/comapeo_observations.py
+++ b/f/frizzle/comapeo/comapeo_observations.py
@@ -20,9 +20,10 @@ logger = logging.getLogger(__name__)
 
 def conninfo(db: postgresql):
     """Convert a `postgresql` Windmill Resources to psycopg-style connection string"""
-    return "dbname={dbname} user={user} password={password} host={host} port={port}".format(
-        **db
-    )
+    # password is optional
+    password_part = f" password={db['password']}" if "password" in db else ""
+    conn = "dbname={dbname} user={user} host={host} port={port}".format(**db)
+    return conn + password_part
 
 
 def main(

--- a/f/frizzle/kobotoolbox/kobotoolbox_responses.py
+++ b/f/frizzle/kobotoolbox/kobotoolbox_responses.py
@@ -22,7 +22,10 @@ logger = logging.getLogger(__name__)
 
 def conninfo(db: postgresql):
     """Convert a `postgresql` Windmill Resources to psycopg-style connection string"""
-    return " ".join(f"{k}={v}" for k, v in db.items())
+    # password is optional
+    password_part = f" password={db['password']}" if "password" in db else ""
+    conn = "dbname={dbname} user={user} host={host} port={port}".format(**db)
+    return conn + password_part
 
 
 def main(


### PR DESCRIPTION
## Goal

Fixes #24

## What I changed

The challenge is that this conninfo string needs to contain different keys when running in Windmill vs in tests.  In particular the test does not have `password` set.

This PR makes `password` optional, while still limiting the conninfo string to a specific set of fields (e.g. NOT `root_certificate_pem`)
## How I know it works

- [x] tests still pass
- [x] I ran it on our demo deployment, and it now passes
