### PR TITLE
Add `postgres_to_geojson` export script

### DIFF
--- a/f/export/README.md
+++ b/f/export/README.md
@@ -1,0 +1,3 @@
+# Export
+
+A set of scripts for exporting data from a data warehouse into a variety of different formats.

--- a/f/export/folder.meta.yaml
+++ b/f/export/folder.meta.yaml
@@ -1,0 +1,6 @@
+summary: null
+display_name: export
+extra_perms:
+  u/rudo: true
+owners:
+  - u/rudo

--- a/f/export/folder.meta.yaml
+++ b/f/export/folder.meta.yaml
@@ -1,2 +1,1 @@
-summary: A collection of export scripts
 display_name: export

--- a/f/export/folder.meta.yaml
+++ b/f/export/folder.meta.yaml
@@ -1,6 +1,2 @@
-summary: null
+summary: A collection of export scripts
 display_name: export
-extra_perms:
-  u/rudo: true
-owners:
-  - u/rudo

--- a/f/export/postgres_to_geojson/postgres_to_geojson.py
+++ b/f/export/postgres_to_geojson/postgres_to_geojson.py
@@ -85,7 +85,7 @@ def format_data_as_geojson(data):
         geometry = {}
         feature_id = None
 
-        # The expectated schema here is that geometry columns are prefixed with "g__"
+        # The expected schema here is that geometry columns are prefixed with "g__"
         # If an "_id" column is present, it is used as the feature id
         # All other columns are treated as properties
         for col, value in zip(columns, row):

--- a/f/export/postgres_to_geojson/postgres_to_geojson.py
+++ b/f/export/postgres_to_geojson/postgres_to_geojson.py
@@ -35,6 +35,19 @@ def main(
 
 
 def fetch_data_from_postgres(db_connection_string, table_name: str):
+    """
+    Fetches all data from a specified PostgreSQL table.
+
+    Parameters
+    ----------
+        db_connection_string (str): The connection string for the PostgreSQL database.
+        table_name (str): The name of the table to fetch data from.
+
+    Returns
+    -------
+        tuple: A tuple containing a list of column names and a list of rows fetched from the table.
+    """
+
     try:
         conn = psycopg2.connect(db_connection_string)
         cursor = conn.cursor()
@@ -43,7 +56,7 @@ def fetch_data_from_postgres(db_connection_string, table_name: str):
         rows = cursor.fetchall()
     except psycopg2.Error as e:
         logger.error(f"Error fetching data from {table_name}: {e}")
-        return None, None
+        raise
     finally:
         cursor.close()
         conn.close()
@@ -56,12 +69,15 @@ def format_data_as_geojson(data):
     """
     Converts data from a PostgreSQL table into a GeoJSON FeatureCollection.
 
-    Args:
+    Parameters
+    ----------
         data (tuple): A tuple containing columns and rows fetched from the database.
 
-    Returns:
+    Returns
+    -------
         dict: A GeoJSON FeatureCollection with features extracted from the data.
     """
+
     columns, rows = data
     features = []
     for row in rows:
@@ -99,6 +115,16 @@ def format_data_as_geojson(data):
 
 
 def save_file(data, db_table_name: str, storage_path: str):
+    """
+    Saves the provided data as a GeoJSON file in the specified storage path.
+
+    Parameters
+    ----------
+        data (dict): The data to be saved, formatted as a GeoJSON FeatureCollection.
+        db_table_name (str): The name of the database table, used to name the output file.
+        storage_path (str): The directory path where the GeoJSON file will be saved.
+    """
+
     try:
         os.makedirs(storage_path, exist_ok=True)
         geojson_path = os.path.join(storage_path, f"{db_table_name}.geojson")

--- a/f/export/postgres_to_geojson/postgres_to_geojson.py
+++ b/f/export/postgres_to_geojson/postgres_to_geojson.py
@@ -1,0 +1,110 @@
+# requirements:
+# psycopg2-binary
+
+import json
+import logging
+import os
+
+import psycopg2
+
+# type names that refer to Windmill Resources
+postgresql = dict
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def conninfo(db: postgresql):
+    """Convert a `postgresql` Windmill Resources to psycopg-style connection string"""
+    # password is optional
+    password_part = f" password={db['password']}" if "password" in db else ""
+    conn = "dbname={dbname} user={user} host={host} port={port}".format(**db)
+    return conn + password_part
+
+
+def main(
+    db: postgresql,
+    db_table_name: str,
+    storage_path: str = "/frizzle-persistent-storage/datalake/export",
+):
+    data = fetch_data_from_postgres(conninfo(db), db_table_name)
+
+    feature_collection = format_data_as_geojson(data)
+
+    save_file(feature_collection, db_table_name, storage_path)
+
+
+def fetch_data_from_postgres(db_connection_string, table_name: str):
+    try:
+        conn = psycopg2.connect(db_connection_string)
+        cursor = conn.cursor()
+        cursor.execute(f"SELECT * FROM {table_name};")
+        columns = [desc[0] for desc in cursor.description]
+        rows = cursor.fetchall()
+    except psycopg2.Error as e:
+        logger.error(f"Error fetching data from {table_name}: {e}")
+        return None, None
+    finally:
+        cursor.close()
+        conn.close()
+
+    logger.info(f"Data fetched from {table_name}")
+    return columns, rows
+
+
+def format_data_as_geojson(data):
+    """
+    Converts data from a PostgreSQL table into a GeoJSON FeatureCollection.
+
+    Args:
+        data (tuple): A tuple containing columns and rows fetched from the database.
+
+    Returns:
+        dict: A GeoJSON FeatureCollection with features extracted from the data.
+    """
+    columns, rows = data
+    features = []
+    for row in rows:
+        properties = {}
+        geometry = {}
+        feature_id = None
+
+        # The expectated schema here is that geometry columns are prefixed with "g__"
+        # If an "_id" column is present, it is used as the feature id
+        # All other columns are treated as properties
+        for col, value in zip(columns, row):
+            if col == "_id":
+                feature_id = value
+            elif col.startswith("g__"):
+                geometry[col[3:]] = value
+            else:
+                properties[col] = value
+
+        feature = {
+            "type": "Feature",
+            "id": feature_id,
+            "properties": properties,
+            "geometry": geometry,
+        }
+        features.append(feature)
+
+    feature_collection = {
+        "type": "FeatureCollection",
+        "features": features,
+    }
+
+    logger.info(f"GeoJSON created with {len(features)} features")
+
+    return feature_collection
+
+
+def save_file(data, db_table_name: str, storage_path: str):
+    try:
+        os.makedirs(storage_path, exist_ok=True)
+        geojson_path = os.path.join(storage_path, f"{db_table_name}.geojson")
+        with open(geojson_path, "w") as f:
+            json.dump(data, f)
+    except OSError as e:
+        logger.error(f"Error saving file {geojson_path}: {e}")
+    else:
+        logger.info(f"GeoJSON file saved to {geojson_path}")

--- a/f/export/postgres_to_geojson/postgres_to_geojson.py
+++ b/f/export/postgres_to_geojson/postgres_to_geojson.py
@@ -125,12 +125,8 @@ def save_file(data, db_table_name: str, storage_path: str):
         storage_path (str): The directory path where the GeoJSON file will be saved.
     """
 
-    try:
-        os.makedirs(storage_path, exist_ok=True)
-        geojson_path = os.path.join(storage_path, f"{db_table_name}.geojson")
-        with open(geojson_path, "w") as f:
-            json.dump(data, f)
-    except OSError as e:
-        logger.error(f"Error saving file {geojson_path}: {e}")
-    else:
-        logger.info(f"GeoJSON file saved to {geojson_path}")
+    os.makedirs(storage_path, exist_ok=True)
+    geojson_path = os.path.join(storage_path, f"{db_table_name}.geojson")
+    with open(geojson_path, "w") as f:
+        json.dump(data, f)
+    logger.info(f"GeoJSON file saved to {geojson_path}")

--- a/f/export/postgres_to_geojson/postgres_to_geojson.py
+++ b/f/export/postgres_to_geojson/postgres_to_geojson.py
@@ -6,7 +6,7 @@ import logging
 
 from pathlib import Path
 
-import psycopg2
+from psycopg2 import sql, connect, Error
 
 # type names that refer to Windmill Resources
 postgresql = dict
@@ -50,12 +50,16 @@ def fetch_data_from_postgres(db_connection_string, table_name: str):
     """
 
     try:
-        conn = psycopg2.connect(db_connection_string)
+        conn = connect(db_connection_string)
         cursor = conn.cursor()
-        cursor.execute(f"SELECT * FROM {table_name};")
+        cursor.execute(
+            sql.SQL("SELECT * FROM {table_name}").format(
+                table_name=sql.Identifier(table_name)
+            )
+        )
         columns = [desc[0] for desc in cursor.description]
         rows = cursor.fetchall()
-    except psycopg2.Error as e:
+    except Error as e:
         logger.error(f"Error fetching data from {table_name}: {e}")
         raise
     finally:

--- a/f/export/postgres_to_geojson/postgres_to_geojson.py
+++ b/f/export/postgres_to_geojson/postgres_to_geojson.py
@@ -3,7 +3,8 @@
 
 import json
 import logging
-import os
+
+from pathlib import Path
 
 import psycopg2
 
@@ -125,8 +126,9 @@ def save_file(data, db_table_name: str, storage_path: str):
         storage_path (str): The directory path where the GeoJSON file will be saved.
     """
 
-    os.makedirs(storage_path, exist_ok=True)
-    geojson_path = os.path.join(storage_path, f"{db_table_name}.geojson")
-    with open(geojson_path, "w") as f:
+    storage_path = Path(storage_path)
+    storage_path.mkdir(parents=True, exist_ok=True)
+    geojson_path = storage_path / f"{db_table_name}.geojson"
+    with geojson_path.open("w") as f:
         json.dump(data, f)
     logger.info(f"GeoJSON file saved to {geojson_path}")

--- a/f/export/postgres_to_geojson/postgres_to_geojson.script.lock
+++ b/f/export/postgres_to_geojson/postgres_to_geojson.script.lock
@@ -1,0 +1,1 @@
+psycopg2-binary==2.9.10

--- a/f/export/postgres_to_geojson/postgres_to_geojson.script.yaml
+++ b/f/export/postgres_to_geojson/postgres_to_geojson.script.yaml
@@ -3,7 +3,7 @@ description: >-
   This script connects to a PostgreSQL database, retrieves all entries from a
   specified table, and converts the data into GeoJSON format. The script assumes
   that the geometry fields are properly formatted for GeoJSON.
-lock: '!inline f/export/postgres_to_geojson.script.lock'
+lock: '!inline f/export/postgres_to_geojson/postgres_to_geojson.script.lock'
 concurrency_time_window_s: 0
 kind: script
 schema:
@@ -14,13 +14,6 @@ schema:
     - db_table_name
     - storage_path
   properties:
-    storage_path:
-      type: string
-      description: >-
-        The path to the directory where the GeoJSON file will be stored. The
-        file will be named after the database table name.
-      default: /frizzle-persistent-storage/datalake/exports
-      originalType: string
     db:
       type: object
       description: A database connection for storing tabular data.
@@ -30,6 +23,13 @@ schema:
       type: string
       description: The name of the database table to export to GeoJSON.
       default: null
+      originalType: string
+    storage_path:
+      type: string
+      description: >-
+        The path to the directory where the GeoJSON file will be stored. The
+        file will be named after the database table name.
+      default: /frizzle-persistent-storage/datalake/exports
       originalType: string
   required:
     - db

--- a/f/export/postgres_to_geojson/postgres_to_geojson.script.yaml
+++ b/f/export/postgres_to_geojson/postgres_to_geojson.script.yaml
@@ -1,0 +1,37 @@
+summary: 'Export: Postgres to GeoJSON'
+description: >-
+  This script connects to a PostgreSQL database, retrieves all entries from a
+  specified table, and converts the data into GeoJSON format. The script assumes
+  that the geometry fields are properly formatted for GeoJSON.
+lock: '!inline f/export/postgres_to_geojson.script.lock'
+concurrency_time_window_s: 0
+kind: script
+schema:
+  $schema: 'https://json-schema.org/draft/2020-12/schema'
+  type: object
+  order:
+    - db
+    - db_table_name
+    - storage_path
+  properties:
+    storage_path:
+      type: string
+      description: >-
+        The path to the directory where the GeoJSON file will be stored. The
+        file will be named after the database table name.
+      default: /frizzle-persistent-storage/datalake/exports
+      originalType: string
+    db:
+      type: object
+      description: A database connection for storing tabular data.
+      default: null
+      format: resource-postgresql
+    db_table_name:
+      type: string
+      description: The name of the database table to export to GeoJSON.
+      default: null
+      originalType: string
+  required:
+    - db
+    - db_table_name
+    - storage_path

--- a/f/export/postgres_to_geojson/tests/conftest.py
+++ b/f/export/postgres_to_geojson/tests/conftest.py
@@ -6,12 +6,18 @@ import psycopg2
 
 @pytest.fixture
 def pg_database():
+    """A dsn that may be used to connect to a live (local for test) postgresql server"""
     db = testing.postgresql.Postgresql(port=7654)
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
+    yield dsn
+    db.stop()
 
-    # Connect to the database and create the table
-    conn = psycopg2.connect(**dsn)
+
+@pytest.fixture
+def database_mock_data(pg_database):
+    """Fixture to insert mock data into the test database"""
+    conn = psycopg2.connect(**pg_database)
     cursor = conn.cursor()
     cursor.execute("""
         CREATE TABLE comapeo_data (
@@ -31,18 +37,13 @@ def pg_database():
             lon TEXT
         );
     """)
-
-    # Insert the provided data
     cursor.execute("""
         INSERT INTO comapeo_data VALUES
         ('doc_id_1', '-33.8688', 'False', '2024-10-14T20:18:14.206Z', '2024-10-14T20:18:14.206Z', 'Forest Expedition', 'water', 'Point', '[151.2093, -33.8688]', 'capybara.jpg', 'Rapid', 'forest_expedition', NULL, '151.2093'),
         ('doc_id_2', '48.8566', 'False', '2024-10-15T21:19:15.207Z', '2024-10-15T21:19:15.207Z', 'River Mapping', 'animal', 'Point', '[2.3522, 48.8566]', 'capybara.jpg', 'Capybara', 'river_mapping', 'capybara', '2.3522'),
         ('doc_id_3', 35.6895, 'False', '2024-10-16T22:20:16.208Z', '2024-10-16T22:20:16.208Z', 'Historical Site', 'location', 'Point', '[139.6917, 35.6895]', NULL, 'Former village site', 'historical', NULL, '139.6917');
     """)
-
     conn.commit()
     cursor.close()
     conn.close()
-
-    yield dsn
-    db.stop()
+    yield pg_database

--- a/f/export/postgres_to_geojson/tests/conftest.py
+++ b/f/export/postgres_to_geojson/tests/conftest.py
@@ -1,0 +1,48 @@
+import pytest
+import testing.postgresql
+
+import psycopg2
+
+
+@pytest.fixture
+def pg_database():
+    db = testing.postgresql.Postgresql(port=7654)
+    dsn = db.dsn()
+    dsn["dbname"] = dsn.pop("database")
+
+    # Connect to the database and create the table
+    conn = psycopg2.connect(**dsn)
+    cursor = conn.cursor()
+    cursor.execute("""
+        CREATE TABLE comapeo_data (
+            _id TEXT,
+            lat TEXT,
+            deleted TEXT,
+            created_at TEXT,
+            updated_at TEXT,
+            project_name TEXT,
+            type TEXT,
+            g__type TEXT,
+            g__coordinates TEXT,
+            attachments TEXT,
+            notes TEXT,
+            project_id TEXT,
+            animal_type TEXT,
+            lon TEXT
+        );
+    """)
+
+    # Insert the provided data
+    cursor.execute("""
+        INSERT INTO comapeo_data VALUES
+        ('doc_id_1', '-33.8688', 'False', '2024-10-14T20:18:14.206Z', '2024-10-14T20:18:14.206Z', 'Forest Expedition', 'water', 'Point', '[151.2093, -33.8688]', 'capybara.jpg', 'Rapid', 'forest_expedition', NULL, '151.2093'),
+        ('doc_id_2', '48.8566', 'False', '2024-10-15T21:19:15.207Z', '2024-10-15T21:19:15.207Z', 'River Mapping', 'animal', 'Point', '[2.3522, 48.8566]', 'capybara.jpg', 'Capybara', 'river_mapping', 'capybara', '2.3522'),
+        ('doc_id_3', 35.6895, 'False', '2024-10-16T22:20:16.208Z', '2024-10-16T22:20:16.208Z', 'Historical Site', 'location', 'Point', '[139.6917, 35.6895]', NULL, 'Former village site', 'historical', NULL, '139.6917');
+    """)
+
+    conn.commit()
+    cursor.close()
+    conn.close()
+
+    yield dsn
+    db.stop()

--- a/f/export/postgres_to_geojson/tests/postgres_to_geojson_test.py
+++ b/f/export/postgres_to_geojson/tests/postgres_to_geojson_test.py
@@ -1,0 +1,26 @@
+from f.export.postgres_to_geojson.postgres_to_geojson import main
+import json
+
+
+def test_script_e2e(pg_database, tmp_path):
+    asset_storage = tmp_path / "datalake/export"
+
+    main(
+        pg_database,
+        "comapeo_data",
+        asset_storage,
+    )
+
+    with open(asset_storage / "comapeo_data.geojson") as f:
+        data = json.load(f)
+
+        assert data["type"] == "FeatureCollection"
+        assert isinstance(data["features"], list)
+        for feature in data["features"]:
+            assert feature["type"] == "Feature"
+            assert "geometry" in feature
+            assert "properties" in feature
+
+        assert data["features"][0]["id"] == "doc_id_1"
+        assert data["features"][0]["geometry"]["coordinates"] == "[151.2093, -33.8688]"
+        assert data["features"][0]["properties"]["project_name"] == "Forest Expedition"

--- a/f/export/postgres_to_geojson/tests/postgres_to_geojson_test.py
+++ b/f/export/postgres_to_geojson/tests/postgres_to_geojson_test.py
@@ -2,7 +2,7 @@ from f.export.postgres_to_geojson.postgres_to_geojson import main
 import json
 
 
-def test_script_e2e(pg_database, tmp_path):
+def test_script_e2e(pg_database, database_mock_data, tmp_path):
     asset_storage = tmp_path / "datalake/export"
 
     main(

--- a/f/export/postgres_to_geojson/tests/requirements-test.txt
+++ b/f/export/postgres_to_geojson/tests/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest
+testing.postgresql

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-env_list = alerts, comapeo_observations, kobotoolbox
+env_list = alerts, comapeo_observations, kobotoolbox, postgres_to_geojson
 
 [testenv]
 setenv =
@@ -35,3 +35,10 @@ deps =
     -r{toxinidir}/f/frizzle/kobotoolbox/tests/requirements-test.txt
 commands =
     pytest {posargs} f/frizzle/kobotoolbox
+
+[testenv:postgres_to_geojson]
+deps =
+    -r{toxinidir}/f/export/postgres_to_geojson/postgres_to_geojson.script.lock
+    -r{toxinidir}/f/export/postgres_to_geojson/tests/requirements-test.txt
+commands =
+    pytest {posargs} f/export/postgres_to_geojson


### PR DESCRIPTION
_Note: there is absolutely no rush in reviewing this. I felt inspired to try this out this morning, but there is no immediate need to have this merged._

## Goal

The objective here is twofold:

1. To explore and generate discussion about how Windmill can be utilized for unscheduled, non-"frizzle" tasks for GuardianConnector usage.
2. In so doing, to use a real task pulled from our [private `gc-programs`](https://github.com/ConservationMetrics/gc-programs/tree/main/scripts/postgres-to-geojson-converter) repo that I run at least a few times a year for one of our community partners: generating a GeoJSON file from a database table that has geometry columns (that is, not PostGIS `geometry`, but `g__type` and `g__coordinates`).

The vision here is that when a community partner requests to have a spatial data file generated from one of their db tables (e.g. CoMapeo data or KoboToolbox data with geometry columns), a Windmill user can run this script as a one-off to generate a GeoJSON file on their datalake. The GeoJSON export can then be accessed, and shared, via FileBrowser. No more need for running a script in command line (the status quo).

## Screenshots

![image](https://github.com/user-attachments/assets/39f1912b-c2d7-4204-aa8e-9060b3915fe0)

## What I changed

1. Created an `f/export/` dir to store this script and any other export scripts we may want to create. I am not convinced this is the best name and open to suggestions.
2. Added a `postgres_to_geojson` script with all of the expected Windmill bells and whistles. It mostly follows the same operations as the script in `gc-programs`, but I added some error handling and documentation.
3. Added an e2e test for the script.