### PR TITLE
Add "confidence" to alerts table

### DIFF
--- a/f/frizzle/alerts/alerts_gcs.py
+++ b/f/frizzle/alerts/alerts_gcs.py
@@ -377,7 +377,7 @@ class AlertsDBWriter:
                     year text NOT NULL,
                     total_alerts text NOT NULL,
                     description_alerts text,
-                    confidence smallint,
+                    confidence real,
                     metadata_uuid text,
                     source text,
                     alert_source text
@@ -396,7 +396,7 @@ class AlertsDBWriter:
                 alert_type text,
                 area_alert_ha double precision,  -- only present for polygon
                 basin_id bigint,
-                confidence smallint,
+                confidence real,
                 count bigint,
                 date_end_t0 text,
                 date_end_t1 text,
@@ -554,7 +554,7 @@ class AlertsDBWriter:
 
                     if confidence is not None:
                         try:
-                            confidence = int(confidence)
+                            confidence = float(confidence)
                         except ValueError:
                             confidence = None
 

--- a/f/frizzle/alerts/alerts_gcs.py
+++ b/f/frizzle/alerts/alerts_gcs.py
@@ -377,7 +377,7 @@ class AlertsDBWriter:
                     year text NOT NULL,
                     total_alerts text NOT NULL,
                     description_alerts text,
-                    confidence text,
+                    confidence smallint,
                     metadata_uuid text,
                     source text,
                     alert_source text
@@ -396,6 +396,7 @@ class AlertsDBWriter:
                 alert_type text,
                 area_alert_ha double precision,  -- only present for polygon
                 basin_id bigint,
+                confidence smallint,
                 count bigint,
                 date_end_t0 text,
                 date_end_t1 text,
@@ -457,6 +458,7 @@ class AlertsDBWriter:
                             alert_type = properties.get("alert_type")
                             area_alert_ha = properties.get("area_alert_ha")
                             basin_id = properties.get("basin_id")
+                            confidence = properties.get("confidence")
                             count = properties.get("count")
                             date_end_t0 = properties.get("date_end_t0")
                             date_end_t1 = properties.get("date_end_t1")
@@ -479,7 +481,7 @@ class AlertsDBWriter:
                             length_alert_km = properties.get("length_alert_km")
 
                             # Inserting data into the alerts table
-                            query = f"""INSERT INTO {table_name} (_id, alert_type, area_alert_ha, basin_id, count, date_end_t0, date_end_t1, date_start_t0, date_start_t1, grid, label, month_detec, sat_detect_prefix, sat_viz_prefix, satellite, territory_id, territory_name, year_detec, source, g__type, g__coordinates, length_alert_km, alert_source) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s); """
+                            query = f"""INSERT INTO {table_name} (_id, alert_type, area_alert_ha, basin_id, confidence, count, date_end_t0, date_end_t1, date_start_t0, date_start_t1, grid, label, month_detec, sat_detect_prefix, sat_viz_prefix, satellite, territory_id, territory_name, year_detec, source, g__type, g__coordinates, length_alert_km, alert_source) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);"""
 
                             # Execute the query
                             cursor.execute(
@@ -489,6 +491,7 @@ class AlertsDBWriter:
                                     alert_type,
                                     area_alert_ha,
                                     basin_id,
+                                    confidence,
                                     count,
                                     date_end_t0,
                                     date_end_t1,
@@ -551,7 +554,7 @@ class AlertsDBWriter:
 
                     if confidence is not None:
                         try:
-                            confidence = float(confidence)
+                            confidence = int(confidence)
                         except ValueError:
                             confidence = None
 

--- a/f/frizzle/alerts/tests/assets/alerts.geojson
+++ b/f/frizzle/alerts/tests/assets/alerts.geojson
@@ -27,6 +27,7 @@
         "alert_type": "illegal_fishing",
         "area_alert_ha": 2.345,
         "basin_id": 1234567,
+        "confidence": 1,
         "count": 47,
         "date_end_t0": "2023-05-15",
         "date_end_t1": "2023-11-15",


### PR DESCRIPTION

## What I changed

1. Add confidence to "alerts" SQL table.
    - `smallint` as the only values I've seen in the wild are {0, 1}
    - @rudokemper do you know what this column means?  Is there reason to believe it could contain values that aren't smallint?

2. Change datatype for "alerts__metadata.confidence" column.
    - `smallint` as the only values I've seen in the wild are {0, 1}.
        - Therefore changed the typecast from `float` to `int`.
    - @rudokemper do you know what this column means?  Is there reason to believe it could contain values that aren't smallint?

## What I'm not doing here

Tests for different values of these columns.