### PR TITLE
Clean up `kobo_responses.py` script

### DIFF
--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -4,9 +4,9 @@
 
 import json
 import logging
-import os
 import re
 import time
+from pathlib import Path
 
 import psycopg2
 import requests
@@ -87,13 +87,13 @@ def download_attachments(
                     response = requests.get(attachment["download_url"], headers=headers)
                     if response.status_code == 200:
                         file_name = attachment["filename"]
-                        save_path = os.path.join(
-                            attachment_root,
-                            dataset_id,
-                            "attachments",
-                            os.path.basename(file_name),
+                        save_path = (
+                            Path(attachment_root)
+                            / dataset_id
+                            / "attachments"
+                            / Path(file_name).name
                         )
-                        os.makedirs(os.path.dirname(save_path), exist_ok=True)
+                        save_path.parent.mkdir(parents=True, exist_ok=True)
                         with open(save_path, "wb") as file:
                             file.write(response.content)
                         logger.debug(

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -38,18 +38,95 @@ def main(
     kobo_server_base_url = kobotoolbox["server_url"]
     kobo_api_key = kobotoolbox["api_key"]
 
-    form_data = download_form_and_attachments(
+    form_data = download_form_responses_and_attachments(
         kobo_server_base_url, kobo_api_key, form_id, attachment_root
     )
 
     db_writer = KoboDBWriter(conninfo(db), db_table_name)
     db_writer.handle_output(form_data)
-    logger.info(f"Wrote response content to database table [{db_table_name}]")
+    logger.info(
+        f"KoboToolbox responses successfully written to database table: [{db_table_name}]"
+    )
 
 
-def download_form_and_attachments(
+def download_attachments(
+    form_submissions, form_name, dataset_id, attachment_root, headers
+):
+    """Download attachments from form submissions and save them locally.
+
+    This function iterates over form submissions, injecting form name and ID into each submission.
+    If attachments are present, it downloads them using the provided headers and saves them
+    to a specified root directory.
+
+    Parameters
+    ----------
+    form_submissions : list
+        A list of form submissions containing potential attachments.
+    form_name : str
+        The name of the form, used for injecting into each submission.
+    dataset_id : str
+        The dataset identifier, used for constructing the save path.
+    attachment_root : str
+        The root directory where attachments will be saved.
+    headers : dict
+        HTTP headers used for downloading attachments.
+
+    Returns
+    -------
+    None
+
+    TODO: Add retries for failed downloads.
+    """
+    for submission in form_submissions:
+        submission["dataset_name"] = form_name
+        submission["dataset_id"] = dataset_id
+
+        if "_attachments" in submission:
+            for attachment in submission["_attachments"]:
+                if "download_url" in attachment:
+                    response = requests.get(attachment["download_url"], headers=headers)
+                    if response.status_code == 200:
+                        file_name = attachment["filename"]
+                        save_path = os.path.join(
+                            attachment_root,
+                            dataset_id,
+                            "attachments",
+                            os.path.basename(file_name),
+                        )
+                        os.makedirs(os.path.dirname(save_path), exist_ok=True)
+                        with open(save_path, "wb") as file:
+                            file.write(response.content)
+                        logger.debug(
+                            "Download completed: " + attachment["download_url"]
+                        )
+                    else:
+                        logger.error("Failed downloading attachments.")
+
+
+def download_form_responses_and_attachments(
     server_base_url, kobo_api_key, form_id, attachment_root
 ):
+    """Download form responses and their attachments from KoboToolbox.
+
+    This function retrieves form metadata and submissions from the KoboToolbox API,
+    downloads any attachments, and logs the number of submissions processed.
+
+    Parameters
+    ----------
+    server_base_url : str
+        The base URL of the KoboToolbox server.
+    kobo_api_key : str
+        The API key for authenticating requests to the KoboToolbox server.
+    form_id : str
+        The unique identifier of the form to download.
+    attachment_root : str
+        The root directory where attachments will be saved.
+
+    Returns
+    -------
+    list
+        A list of form submissions including any downloaded attachments.
+    """
     headers = {
         "Authorization": f"Token {kobo_api_key}",
         "Accept": "application/json, text/javascript, */*; q=0.01",
@@ -67,46 +144,31 @@ def download_form_and_attachments(
     response = requests.get(data_uri, headers=headers)
     response.raise_for_status()
 
-    all_submissions = response.json()["results"]
+    form_submissions = response.json()["results"]
 
-    for submission in all_submissions:
-        # Inject the form name/id to each submission.
-        # Thus these fields will be added as columns along with all the other submission info later on.
-        submission["dataset_name"] = form_name
-        submission["dataset_id"] = dataset_id
-
-        # If the result has attachments, download them.
-        if "_attachments" in submission:
-            for attachment in submission["_attachments"]:
-                if "download_url" in attachment:
-                    response = requests.get(attachment["download_url"], headers=headers)
-                    if response.status_code == 200:
-                        file_name = attachment["filename"]
-                        # ie. datalake/{dataset_id}/attachments/{files}
-                        save_path = os.path.join(
-                            attachment_root,
-                            dataset_id,
-                            "attachments",
-                            os.path.basename(file_name),
-                        )
-                        os.makedirs(os.path.dirname(save_path), exist_ok=True)
-                        with open(save_path, "wb") as file:
-                            file.write(response.content)
-                        logger.debug(
-                            "Download completed: " + attachment["download_url"]
-                        )
-                    else:
-                        # TODO: add retries
-                        logger.error("Failed downloading attachments.")
+    download_attachments(
+        form_submissions, form_name, dataset_id, attachment_root, headers
+    )
 
     logger.info(
-        f"[Form {form_id}] Downloaded {len(all_submissions)} submission(s), including attachments."
+        f"[Form {form_id}] Downloaded {len(form_submissions)} submission(s), including attachments."
     )
-    return all_submissions
+    return form_submissions
 
 
 def sanitize_form_name(form_name):
-    # sanitizes form_name string for path creation
+    """Sanitize a form name for use in file paths.
+
+    Parameters
+    ----------
+    form_name : str
+        The original form name to be sanitized.
+
+    Returns
+    -------
+    str
+        A sanitized version of the form name.
+    """
     name = re.sub(r"[\s()]", "_", form_name)
     name = re.sub(r"[^a-zA-Z0-9_-]", "", name)
     name = name.lstrip("-")
@@ -114,14 +176,59 @@ def sanitize_form_name(form_name):
 
 
 def _reverse_parts(k, sep="/"):
+    """Reverse the parts of a string separated by a given separator.
+
+    Parameters
+    ----------
+    k : str
+        The string to be reversed.
+    sep : str, optional
+        The separator used to split and join the string parts, by default "/".
+
+    Returns
+    -------
+    str
+        The string with its parts reversed.
+    """
     return sep.join(reversed(k.split(sep)))
 
 
 def _drop_nonsql_chars(s):
+    """Remove non-SQL compatible characters from a string.
+
+    Parameters
+    ----------
+    s : str
+        The string from which to remove non-SQL characters.
+
+    Returns
+    -------
+    str
+        The cleaned string with non-SQL characters removed.
+    """
     return re.sub(r"[ ./?\[\]\\,<>(){}]", "", s)
 
 
 def _shorten_and_uniqify(key, conflicts, maxlen):
+    """Shorten a key and ensure its uniqueness within a set of conflicts.
+
+    This function truncates a key to a specified maximum length and appends a
+    numeric suffix if necessary to ensure uniqueness within a set of conflicting keys.
+
+    Parameters
+    ----------
+    key : str
+        The original key to be shortened and made unique.
+    conflicts : set
+        A set of keys that the new key must not conflict with.
+    maxlen : int
+        The maximum allowed length for the key.
+
+    Returns
+    -------
+    str
+        A shortened and unique version of the key.
+    """
     counter = 1
     new_key = key[:maxlen]
     while new_key in conflicts:
@@ -137,6 +244,30 @@ def sanitize(
     str_replace=[],
     maxlen=63,  # https://stackoverflow.com/a/27865772
 ):
+    """Sanitize a message for SQL compatibility and rename columns.
+
+    This function processes a message dictionary, converting lists and dictionaries
+    to JSON strings, renaming columns based on provided mappings, and ensuring
+    SQL compatibility of keys.
+
+    Parameters
+    ----------
+    message : dict
+        The original message dictionary to be sanitized.
+    column_renames : dict
+        A dictionary mapping original column names to their new names.
+    reverse_properties_separated_by : str, optional
+        A separator for reversing property names, by default None.
+    str_replace : list, optional
+        A list of tuples specifying string replacements, by default [].
+    maxlen : int, optional
+        The maximum length for SQL-compatible keys, by default 63.
+
+    Returns
+    -------
+    tuple
+        A tuple containing the sanitized message and updated column renames.
+    """
     column_renames = column_renames.copy()
     sql_message = {}
     for original_key, value in message.items():
@@ -147,7 +278,6 @@ def sanitize(
             sql_message[column_renames[original_key]] = value
             continue
 
-        # transform
         key = original_key
         if reverse_properties_separated_by:
             key = _reverse_parts(original_key, reverse_properties_separated_by)
@@ -354,7 +484,6 @@ class KoboDBWriter:
 
         existing_fields = self._get_existing_cols(table_name)
         existing_columns_map = self._get_existing_mappings(table_name + "__columns")
-        incoming_columns_dict = {}
 
         rows = []
         # Iterate over each submission to collect the full set of columns needed
@@ -371,35 +500,27 @@ class KoboDBWriter:
         missing_map_keys = set()
         missing_field_keys = set()
         for sanitized, existing_mappings in rows:
-            # what's in sanitized incoming that we are not supporting currently
+            # Identify keys in the sanitized data that are not currently supported by existing mappings
             missing_map_keys.update(
                 set(sanitized.keys()).difference(set(existing_mappings.values()))
             )
-            diff = set(existing_mappings.values()).difference(existing_fields)
-
-            # what's in existing mapping but it doesn't exist in the form table
-            # NOTE: this can happen when the database is new based off legacy mapping
+            # Identify keys in existing mappings that do not exist in the database table
+            # NOTE: This can occur when the database is newly created based on legacy mappings
             missing_field_keys.update(
                 set(existing_mappings.values()).difference(existing_fields)
             )
 
-            # what's in incoming keys but it doesn't exist in the form table
+            # Identify keys in the sanitized data that do not exist in the database table
             missing_field_keys.update(set(sanitized.keys()).difference(existing_fields))
 
         missing_mappings = {}
         for m in missing_map_keys:
-            # FIXME: need to clean from the database probably instead
-            if m in ["g__coordinates", "_topic", "p___sender", "g__type"]:
-                continue
-            # TODO: write a test for this when it's empty
-            # m is a missing key
+            # TODO: Write a test for this when it's empty
             original = [key for key, val in original_to_sql.items() if val == m]
             if original:
                 original = original[0]
             else:
-                # we don't need to support this sql column
-                # as it doesn't have a matched original to be mapped
-                # and can be skipped
+                # Skip this SQL column as it has no corresponding original key to map from
                 continue
             sql = m
             missing_mappings[str(original)] = sql
@@ -416,8 +537,6 @@ class KoboDBWriter:
 
         if missing_field_keys:
             self._create_missing_fields(table_name, missing_field_keys)
-            updated_fields = self._get_existing_cols(table_name)
-            # assert updated_fields != existing_fields, "{table_name} fields have not been updated properly."
 
         logger.info(f"Inserting {len(rows)} submissions into DB.")
 
@@ -425,7 +544,7 @@ class KoboDBWriter:
             try:
                 cols, vals = zip(*row.items())
 
-                # Serialize lists, dict values to JSON text
+                # Serialize lists and dict values to JSON text
                 vals = list(vals)
                 for i in range(len(vals)):
                     value = vals[i]

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -82,7 +82,7 @@ def _download_submission_attachments(submission, dataset_id, attachment_root, he
                 save_path.parent.mkdir(parents=True, exist_ok=True)
                 with open(save_path, "wb") as file:
                     file.write(response.content)
-                logger.debug(f"Download completed: ${attachment["download_url"]}")
+                logger.debug(f"Download completed: {attachment['download_url']}")
             else:
                 logger.error(
                     f"Failed downloading attachment: {attachment['download_url']}"


### PR DESCRIPTION
## Goal

Towards #20. 

## What I changed

* Created a bespoke helper function `_download_submission_attachments` for downloading attachments from a submission, to improve readability.
* Removed unused variables in `KoboDBWriter`.
* Renamed some variables for improved clarity.
* Added docstrings to functions.
* Removed (or clarified) redundant comments.
* Implemented `pathlib` instead of `os.join`.
