### PR TITLE
For KoboToolbox, construct `g__` fields from `_geolocation` field

### DIFF
--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -42,10 +42,10 @@ def main(
         kobo_server_base_url, kobo_api_key, form_id, attachment_root
     )
 
-    prepared_form_data = prepare_form_data(form_data)
+    transformed_form_data = transform_form_data(form_data)
 
     db_writer = KoboDBWriter(conninfo(db), db_table_name)
-    db_writer.handle_output(prepared_form_data)
+    db_writer.handle_output(transformed_form_data)
     logger.info(
         f"KoboToolbox responses successfully written to database table: [{db_table_name}]"
     )
@@ -147,8 +147,8 @@ def download_form_responses_and_attachments(
     return form_submissions
 
 
-def prepare_form_data(form_data):
-    """Prepare KoboToolbox form data by e.g. detecting and formatting geometry fields for SQL database insertion.
+def transform_form_data(form_data):
+    """Transform KoboToolbox form data by e.g. formatting geometry fields for SQL database insertion.
 
     Parameters
     ----------
@@ -158,7 +158,7 @@ def prepare_form_data(form_data):
     Returns
     -------
     list
-        A list of prepared form submissions.
+        A list of transformed form submissions.
     """
     for submission in form_data:
         geolocation = submission.get("_geolocation")

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -42,7 +42,7 @@ def main(
         kobo_server_base_url, kobo_api_key, form_id, attachment_root
     )
 
-    transformed_form_data = transform_form_data(form_data)
+    transformed_form_data = format_geometry_fields(form_data)
 
     db_writer = KoboDBWriter(conninfo(db), db_table_name)
     db_writer.handle_output(transformed_form_data)
@@ -147,8 +147,8 @@ def download_form_responses_and_attachments(
     return form_submissions
 
 
-def transform_form_data(form_data):
-    """Transform KoboToolbox form data by e.g. formatting geometry fields for SQL database insertion.
+def format_geometry_fields(form_data):
+    """Transform KoboToolbox form data by formatting geometry fields for SQL database insertion.
 
     Parameters
     ----------
@@ -167,7 +167,6 @@ def transform_form_data(form_data):
             submission["g__coordinates"] = geolocation
             del submission["_geolocation"]
 
-        # TODO: consider discarding KoboToolbox meta fields not useful to store in the data warehouse
     return form_data
 
 

--- a/f/connectors/kobotoolbox/tests/kobotoolboxresponses_test.py
+++ b/f/connectors/kobotoolbox/tests/kobotoolboxresponses_test.py
@@ -102,3 +102,9 @@ def test_script_e2e(koboserver, pg_database, tmp_path):
         with conn.cursor() as cursor:
             cursor.execute("SELECT COUNT(*) FROM kobo_responses")
             assert cursor.fetchone()[0] == 3
+
+            # Check that the coordinates of a fixture entry are stored as a Point
+            cursor.execute(
+                "SELECT g__type, g__coordinates FROM kobo_responses WHERE _id = '124961136'"
+            )
+            assert cursor.fetchone() == ("Point", "[36.97012, -122.0109429]")


### PR DESCRIPTION
## Goal

Toward https://github.com/ConservationMetrics/gc-scripts-hub/issues/20. This is stacked on PR https://github.com/ConservationMetrics/gc-scripts-hub/pull/44.

## What I changed

* Added a `transform_form_data` function where we can make transformations to the form data as needed.
* Currently, I am only using this to do one thing: take `_geolocation` to construct `g__type` and `g__coordinates` fields (this seemingly was forgotten in the transition from frizzle-thespian to frizzle-dagster).
* In the future we can also use this function to remove any unwanted fields e.g. meta content.

## What I'm not doing here

I went down a rabbit hole of investigating whether `_geolocation` is ever anything other than a Point. There are polygon and line field options in KoboToolbox but these are never set as `_geolocation`. So I kept things simple and opted not to touch any polygon or line geometry content; it's impossible to know deterministically if these optional fields are ever the intended primary geometry of a given form.