### PR TITLE
Apply `shorten_and_uniqify` to column table

### DIFF
--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -204,7 +204,7 @@ def _drop_nonsql_chars(s):
     return re.sub(r"[ ./?\[\]\\,<>(){}]", "", s)
 
 
-def shorten_and_uniqify(identifier, conflicts, maxlen):
+def _shorten_and_uniqify(identifier, conflicts, maxlen):
     """Shorten an identifier and ensure its uniqueness within a set of conflicts.
 
     This function truncates an identifier to a specified maximum length and appends a
@@ -282,7 +282,7 @@ def sanitize(
         for args in str_replace:
             key = key.replace(*args)
         key = _drop_nonsql_chars(key)
-        key = shorten_and_uniqify(key, updated_column_renames.values(), maxlen)
+        key = _shorten_and_uniqify(key, updated_column_renames.values(), maxlen)
 
         updated_column_renames[original_key] = key
         sanitized_sql_message[key] = value
@@ -474,9 +474,7 @@ class KoboDBWriter:
         all_submissions : list of dict
         """
         table_name = self.table_name
-        columns_table_name = (
-            f"{shorten_and_uniqify(f'{table_name}', set(), 54)}__columns"
-        )
+        columns_table_name = f"{table_name[:54]}__columns"
 
         conn = self._get_conn()
         cursor = conn.cursor()

--- a/f/connectors/kobotoolbox/tests/kobotoolboxresponses_test.py
+++ b/f/connectors/kobotoolbox/tests/kobotoolboxresponses_test.py
@@ -3,7 +3,6 @@ import psycopg2
 from f.connectors.kobotoolbox.kobotoolbox_responses import (
     main,
     sanitize,
-    shorten_and_uniqify,
 )
 
 
@@ -85,18 +84,6 @@ def test_sanitize_with_nesting():
         "group1": '{"group2": {"question": "How ya doin?"}}',
         "url": "gopher://example.net",
     }
-
-
-def test_shorten_and_uniqify_for_columns_table():
-    table_name = "planting_submissions_for_planted_trees_under_our_island_program"
-    shortened_columns_table_name = shorten_and_uniqify(
-        table_name, set(), 54
-    )  # 54 chars to create space for "__columns"
-    columns_table_name = f"{shortened_columns_table_name}__columns"
-    assert (
-        columns_table_name
-        == "planting_submissions_for_planted_trees_under_our_islan__columns"
-    )
 
 
 def test_script_e2e(koboserver, pg_database, tmp_path):

--- a/f/connectors/kobotoolbox/tests/kobotoolboxresponses_test.py
+++ b/f/connectors/kobotoolbox/tests/kobotoolboxresponses_test.py
@@ -1,6 +1,10 @@
 import psycopg2
 
-from f.connectors.kobotoolbox.kobotoolbox_responses import main, sanitize
+from f.connectors.kobotoolbox.kobotoolbox_responses import (
+    main,
+    sanitize,
+    shorten_and_uniqify,
+)
 
 
 def test_sanitize():
@@ -81,6 +85,18 @@ def test_sanitize_with_nesting():
         "group1": '{"group2": {"question": "How ya doin?"}}',
         "url": "gopher://example.net",
     }
+
+
+def test_shorten_and_uniqify_for_columns_table():
+    table_name = "planting_submissions_for_planted_trees_under_our_island_program"
+    shortened_columns_table_name = shorten_and_uniqify(
+        table_name, set(), 54
+    )  # 54 chars to create space for "__columns"
+    columns_table_name = f"{shortened_columns_table_name}__columns"
+    assert (
+        columns_table_name
+        == "planting_submissions_for_planted_trees_under_our_islan__columns"
+    )
 
 
 def test_script_e2e(koboserver, pg_database, tmp_path):

--- a/f/connectors/kobotoolbox/tests/kobotoolboxresponses_test.py
+++ b/f/connectors/kobotoolbox/tests/kobotoolboxresponses_test.py
@@ -1,9 +1,6 @@
 import psycopg2
 
-from f.connectors.kobotoolbox.kobotoolbox_responses import (
-    main,
-    sanitize,
-)
+from f.connectors.kobotoolbox.kobotoolbox_responses import main, sanitize
 
 
 def test_sanitize():


### PR DESCRIPTION
## Goal

This is stacked on PR https://github.com/ConservationMetrics/gc-scripts-hub/pull/44.

In a recent run for one of our users, I noticed that a very long table name resulted in an error when trying to create the columns mapping table. This is because the `db_table_name` had a length of 58 chars, and currently, we brute append `__columns` to the table name, thus violating Postgres's 63 char limit for table names. 

This PR aims to solve that by applying the `shorten_and_uniqify` function (with a `maxlen=54` argument) to the column table name before appending `__columns`.

## What I changed

* Tweaked the language in `shorten_and_uniqify` to reflect usage for many identifiers, not just keys.
* At the very beginning of the `handle_output` method, create a `columns_table_name` string with the function applied with 54 maxlen and `__column` appended, and use that throughout.
* Added a unit test to test the desired behavior for `__column` rewrites.

## What I'm not doing here

Addressing a case when `db_table_name` itself is > 63 chars! Right now we use this argument as given and don't transform it in any way. But I thought to leave that for a different PR, because the same is true for `alerts` and `comapeo` connectors. Maybe there is a way to set a validation in the `script.yaml` file.