### PR TITLE
Reverse KoboToolbox _geolocation coordinates to be GeoJSON compliant

### DIFF
--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -161,10 +161,10 @@ def format_geometry_fields(form_data):
         A list of transformed form submissions.
     """
     for submission in form_data:
-        geolocation = submission.get("_geolocation")
-        if geolocation:
-            submission["g__type"] = "Point"
-            submission["g__coordinates"] = geolocation
+        if "_geolocation" in submission:
+            # Convert [lat, lon] to [lon, lat] for GeoJSON compliance
+            coordinates = submission.pop("_geolocation")[::-1]
+            submission.update({"g__type": "Point", "g__coordinates": coordinates})
             del submission["_geolocation"]
 
     return form_data

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -165,7 +165,6 @@ def format_geometry_fields(form_data):
             # Convert [lat, lon] to [lon, lat] for GeoJSON compliance
             coordinates = submission.pop("_geolocation")[::-1]
             submission.update({"g__type": "Point", "g__coordinates": coordinates})
-            del submission["_geolocation"]
 
     return form_data
 

--- a/f/connectors/kobotoolbox/tests/kobotoolboxresponses_test.py
+++ b/f/connectors/kobotoolbox/tests/kobotoolboxresponses_test.py
@@ -104,8 +104,9 @@ def test_script_e2e(koboserver, pg_database, tmp_path):
             cursor.execute("SELECT COUNT(*) FROM kobo_responses")
             assert cursor.fetchone()[0] == 3
 
-            # Check that the coordinates of a fixture entry are stored as a Point
+            # Check that the coordinates of a fixture entry are stored as a Point,
+            # and that the coordinates are reversed (longitude, latitude).
             cursor.execute(
                 "SELECT g__type, g__coordinates FROM kobo_responses WHERE _id = '124961136'"
             )
-            assert cursor.fetchone() == ("Point", "[36.97012, -122.0109429]")
+            assert cursor.fetchone() == ("Point", "[-122.0109429, 36.97012]")


### PR DESCRIPTION
## Goal

Something else we missed in the transition from `frizzle-thespian` to `frizzle-dagster` is the need to reverse point coordinates from KoboToolbox to be GeoJSON-compliant. 

See https://github.com/ConservationMetrics/frizzle-thespian/blob/5d9f338be119320c0d7ee97f029a46a9999d9d69/utils/common_pull.py#L28-L32.