### PR TITLE
Rename the tox testenv value for KoboToolbox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-env_list = alerts, comapeo_observations, kobotoolbox, postgres_to_geojson
+env_list = alerts, comapeo_observations, kobotoolbox_responses, postgres_to_geojson
 
 [testenv]
 setenv =
@@ -29,7 +29,7 @@ deps =
 commands =
     pytest {posargs} f/connectors/comapeo
 
-[testenv:kobotoolbox]
+[testenv:kobotoolbox_responses]
 deps =
     -r{toxinidir}/f/connectors/kobotoolbox/kobotoolbox_responses.script.lock
     -r{toxinidir}/f/connectors/kobotoolbox/tests/requirements-test.txt


### PR DESCRIPTION
## Goal

I keep running into an issue where my KoboToolbox tox tests fail locally, but work on CircleCI. It seems to be related to pytest:

```
$ tox -e kobotoolbox -vv     
ROOT: 60 D setup logging to DEBUG on pid 1115746 [tox/report.py:222]
kobotoolbox: 172 I find interpreter for spec PythonSpec(path=/usr/bin/python3) [virtualenv/discovery/builtin.py:74]
kobotoolbox: 173 D filesystem is case-sensitive [virtualenv/info.py:26]
kobotoolbox: 173 I proposed PythonInfo(spec=CPython3.10.12.final.0-64, exe=/usr/bin/python3, platform=linux, version='3.10.12 (main, Nov  6 2024, 20:22:13) [GCC 11.4.0]', encoding_fs_io=utf-8-utf-8) [virtualenv/discovery/builtin.py:81]
kobotoolbox: 173 D accepted PythonInfo(spec=CPython3.10.12.final.0-64, exe=/usr/bin/python3, platform=linux, version='3.10.12 (main, Nov  6 2024, 20:22:13) [GCC 11.4.0]', encoding_fs_io=utf-8-utf-8) [virtualenv/discovery/builtin.py:83]
kobotoolbox: 198 W commands[0]> pytest f/connectors/kobotoolbox [tox/tox_env/api.py:427]
kobotoolbox: 201 C exit 2 (0.00 seconds) /home/rudo/Code/CMI/gc-scripts-hub> pytest f/connectors/kobotoolbox [tox/execute/api.py:286]
  kobotoolbox: FAIL code 2 (0.05=setup[0.04]+cmd[0.00] seconds)
  evaluation failed :( (0.14 seconds)
```

Not sure what the issue is. I can only confirm that I have the same version of pytest locally as on CircleCI. 

But noting that the `testenv` for comapeo matches the actual script filename, I tried to do the same for kobotoolbox, i.e. setting `testenv` to `kobotoolbox_responses` as I've done in this PR, and that solves the problem. I think this better matches the convention of `{tool}_{output}` anyway.

(Weirdly enough, if I set the `testenv` value for comapeo to just `comapeo`, that doesn't cause any problems.)