### PR TITLE
Switch alerts `_id` column to UUID type

### DIFF
--- a/f/connectors/alerts/alerts_gcs.py
+++ b/f/connectors/alerts/alerts_gcs.py
@@ -425,7 +425,7 @@ class AlertsDBWriter:
             query = sql.SQL("""
             CREATE TABLE IF NOT EXISTS {table_name}
             (
-                _id character varying(36) NOT NULL PRIMARY KEY,
+                _id uuid PRIMARY KEY,
                 -- These are found in "properties" of an alert Feature:
                 alert_id text,
                 alert_type text,

--- a/f/connectors/alerts/alerts_gcs.py
+++ b/f/connectors/alerts/alerts_gcs.py
@@ -424,7 +424,7 @@ class AlertsDBWriter:
             query = sql.SQL("""
             CREATE TABLE IF NOT EXISTS {table_name}
             (
-                _id bigint NOT NULL PRIMARY KEY,
+                _id numeric NOT NULL PRIMARY KEY,
                 -- These are found in "properties" of an alert Feature:
                 alert_type text,
                 area_alert_ha double precision,  -- only present for polygon

--- a/f/connectors/alerts/tests/assets/alert_202309900112345671.geojson
+++ b/f/connectors/alerts/tests/assets/alert_202309900112345671.geojson
@@ -34,7 +34,7 @@
         "date_start_t0": "2023-04-01",
         "date_start_t1": "2023-11-01",
         "grid": 9,
-        "id": "202309900112345671",
+        "id": "20230990011234567181",
         "label": 5,
         "month_detec": "09",
         "sat_detect_prefix": "S1",


### PR DESCRIPTION
## Goal

A real alerts `_id` value for one of our users has 20 characters, which is "out of range" for Postgres BIGINT column (limit: 9223372036854775807, 19 chars). Since this `_id` field is not computationally relevant, it's better off being NUMERIC which has virtually unlimited precision.