### PR TITLE
Set default value for `str_replace` in KoboDBWriter class

### DIFF
--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -309,10 +309,10 @@ class KoboDBWriter:
         automatically handles table width resizing, row-level updates, most data type
         conversions, and sanitizing kobo field names to be SQL-compatible.
 
-        Example of using `reverse_properties_separated_by`:
+        Example of using `reverse_properties_separated_by` and `str_replace`:
         - incoming field => `{"group1/group2/question": "How do you do?"}`
-        - `reverse_properties_separated_by="/"`
-        - SQL column/value => `{"question/group2/group1": "How do you do?"}`
+        - `reverse_properties_separated_by="/"`, `str_replace=[("/", "__")]`
+        - SQL column/value => `{"question__group2__group1": "How do you do?"}`
 
         Parameters
         ----------

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -298,7 +298,11 @@ class KoboDBWriter:
     """
 
     def __init__(
-        self, db_connection_string, table_name, reverse_properties_separated_by="/"
+        self,
+        db_connection_string,
+        table_name,
+        reverse_properties_separated_by="/",
+        str_replace=[("/", "__")],
     ):
         """
         Component for syncing messages to a SQL database table. This component
@@ -320,10 +324,14 @@ class KoboDBWriter:
             An optional transformation of flat property names: split the name on the
             `reverse_properties_separated_by` character, reverse the parts, then re-concatenate
             them with the same separator.
+        str_replace : list
+            An optional list of tuples specifying string replacements to be applied to the
+            property names.
         """
         self.db_connection_string = db_connection_string
         self.table_name = table_name
         self.reverse_separator = reverse_properties_separated_by
+        self.str_replace = str_replace
 
     def _get_conn(self):
         """
@@ -489,6 +497,7 @@ class KoboDBWriter:
                 submission,
                 existing_columns_map,
                 reverse_properties_separated_by=self.reverse_separator,
+                str_replace=self.str_replace,
             )
             rows.append((sanitized_columns_dict, existing_columns_map))
             original_to_sql.update(updated_columns_map)

--- a/f/connectors/kobotoolbox/tests/kobotoolboxresponses_test.py
+++ b/f/connectors/kobotoolbox/tests/kobotoolboxresponses_test.py
@@ -110,3 +110,9 @@ def test_script_e2e(koboserver, pg_database, tmp_path):
                 "SELECT g__type, g__coordinates FROM kobo_responses WHERE _id = '124961136'"
             )
             assert cursor.fetchone() == ("Point", "[-122.0109429, 36.97012]")
+
+            # Check that meta/instanceID was sanitized to instanceID__meta
+            cursor.execute(
+                "SELECT \"instanceID__meta\" FROM kobo_responses WHERE _id = '124961136'"
+            )
+            assert cursor.fetchone() == ("uuid:e58da38d-3eee-4bd7-8512-4a97ea8fbb01",)


### PR DESCRIPTION
## Goal

I noticed in production instances that KoboToolbox questions like `group1/question` are being rewritten as `questiongroup1` columns. The desired format is `question__group1`.

The reason for this is that we are not currently supplying a `str_replace` list of string replacement tuples to `sanitize()`. 

* In frizzle-thespian, we [provided `str_replace` as an optional `FRIZZLE_CONFIG` var](https://github.com/ConservationMetrics/frizzle-thespian/blob/5d9f338be119320c0d7ee97f029a46a9999d9d69/components/warehouse/__init__.py#L129). 
* In frizzle-dagster, we [provided a default value for `str_replace` in the `sanitize()` function itself](https://github.com/ConservationMetrics/frizzle-dagster/blob/cd89c04bf58c819466a074fd8ebb3f13df0bfa73/dagster/core/core/postgres_io.py#L839).

Here, I am opting to align with how we provide a default value for `reverse_properties_separated_by` in the class `__init__` method. This will make it straightforward to pass arguments for these properties in the future if needed.