### PR TITLE
Implement db_table_name character constraints in Windmill and scripts

### DIFF
--- a/f/connectors/alerts/alerts_gcs.py
+++ b/f/connectors/alerts/alerts_gcs.py
@@ -400,7 +400,7 @@ class AlertsDBWriter:
         return psycopg2.connect(dsn=self.db_connection_string)
 
     def _create_alerts_metadata_table(self, table_name):
-        metadata_table_name = f"{table_name}__metadata"
+        metadata_table_name = f"{table_name[:53]}__metadata"
 
         with self._get_conn() as conn, conn.cursor() as cursor:
             query = sql.SQL("""

--- a/f/connectors/alerts/alerts_gcs.script.yaml
+++ b/f/connectors/alerts/alerts_gcs.script.yaml
@@ -29,7 +29,7 @@ schema:
       description: The name of the database table where alerts will be stored.
       default: null
       originalType: string
-      pattern: '^.{0,53}$'
+      pattern: '^.{1,53}$'
     destination_path:
       type: string
       description: >-

--- a/f/connectors/alerts/alerts_gcs.script.yaml
+++ b/f/connectors/alerts/alerts_gcs.script.yaml
@@ -29,6 +29,7 @@ schema:
       description: The name of the database table where alerts will be stored.
       default: null
       originalType: string
+      pattern: '^.{0,53}$'
     destination_path:
       type: string
       description: >-

--- a/f/connectors/comapeo/comapeo_observations.py
+++ b/f/connectors/comapeo/comapeo_observations.py
@@ -439,6 +439,7 @@ class CoMapeoDBWriter:
         comapeo_projects = outputs
 
         for project_name, project_data in comapeo_projects.items():
+            # TODO: Safely truncate each project_name to 63 characters while retaining uniqueness
             project_db_table_name = project_name[:63]
             existing_fields = self._inspect_schema(project_db_table_name)
             rows = []

--- a/f/connectors/comapeo/comapeo_observations.py
+++ b/f/connectors/comapeo/comapeo_observations.py
@@ -439,7 +439,8 @@ class CoMapeoDBWriter:
         comapeo_projects = outputs
 
         for project_name, project_data in comapeo_projects.items():
-            # TODO: Safely truncate each project_name to 63 characters while retaining uniqueness
+            # Safely truncate each project_name to 63 characters
+            # TODO: ...while retaining uniqueness
             project_db_table_name = project_name[:63]
             existing_fields = self._inspect_schema(project_db_table_name)
             rows = []

--- a/f/connectors/comapeo/comapeo_observations.py
+++ b/f/connectors/comapeo/comapeo_observations.py
@@ -439,7 +439,8 @@ class CoMapeoDBWriter:
         comapeo_projects = outputs
 
         for project_name, project_data in comapeo_projects.items():
-            existing_fields = self._inspect_schema(project_name)
+            project_db_table_name = project_name[:63]
+            existing_fields = self._inspect_schema(project_db_table_name)
             rows = []
             for entry in project_data:
                 sanitized_entry = {
@@ -452,7 +453,7 @@ class CoMapeoDBWriter:
                 missing_field_keys.update(set(row.keys()).difference(existing_fields))
 
             if missing_field_keys:
-                self._create_missing_fields(project_name, missing_field_keys)
+                self._create_missing_fields(project_db_table_name, missing_field_keys)
 
             logger.info(f"Inserting {len(rows)} submissions into DB.")
 
@@ -467,10 +468,10 @@ class CoMapeoDBWriter:
                         if isinstance(value, list) or isinstance(value, dict):
                             vals[i] = json.dumps(value)
 
-                    self._safe_insert(cursor, project_name, cols, vals)
+                    self._safe_insert(cursor, project_db_table_name, cols, vals)
                 except errors.UniqueViolation:
                     logger.debug(
-                        f"Skipping insertion of rows to {project_name} due to UniqueViolation, this _id has been accounted for already in the past."
+                        f"Skipping insertion of rows to {project_db_table_name} due to UniqueViolation, this _id has been accounted for already in the past."
                     )
                     conn.rollback()
                     continue

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.script.yaml
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.script.yaml
@@ -31,7 +31,7 @@ schema:
       description: The name of the database table where the form data will be stored.
       default: null
       originalType: string
-      pattern: '^.{0,54}$'
+      pattern: '^.{1,54}$'
     form_id:
       type: string
       description: The unique identifier of the form to fetch submissions from.

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.script.yaml
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.script.yaml
@@ -31,6 +31,7 @@ schema:
       description: The name of the database table where the form data will be stored.
       default: null
       originalType: string
+      pattern: '^.{0,54}$'
     form_id:
       type: string
       description: The unique identifier of the form to fetch submissions from.


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-scripts-hub/issues/48.

## What I changed

* For alerts, add a regex pattern allowing <53 characters (to allow for adding a `__metadata` table), and truncate the metadata table name in the script too, to be safe.
* For kobo, add a regex pattern allowing <54 characters, following up on https://github.com/ConservationMetrics/gc-scripts-hub/pull/47.
* For comapeo, the table writing convention differs since the script can create multiple project tables at once, each prepended by an optional `db_table_prefix`. So for this script, I opted to truncate at 63 chars for each db table to be created.
  * There is a potential edge case here where multiple projects could get truncated to the same name. I didn't want to take the time to address that here, but I left a TODO comment indicating the same.

## Notes

As far as I could tell by looking at other Windmill code and the sparse documentation (https://www.windmill.dev/docs/core_concepts/json_schema_and_parsing#advanced-settings), regex is the only way to do this. There is no `maxLength` or similar setting for String types. The regex validation failure message is a bit ugly on the front end but it works:

![image](https://github.com/user-attachments/assets/73b85091-1d24-48fb-8653-28acc330ce3d)