### PR TITLE
Connector scripts create a `data_source` property to write to the db table

### DIFF
--- a/f/connectors/comapeo/comapeo_observations.py
+++ b/f/connectors/comapeo/comapeo_observations.py
@@ -274,6 +274,7 @@ def download_and_transform_comapeo_data(
         for i, observation in enumerate(current_project_data):
             observation["project_name"] = project_name
             observation["project_id"] = project_id
+            observation["data_source"] = "CoMapeo"
 
             # Create k/v pairs for each tag
             for key, value in observation.pop("tags", {}).items():

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -132,6 +132,7 @@ def download_form_responses_and_attachments(
 
     for submission in form_submissions:
         submission["dataset_name"] = form_name
+        submission["data_source"] = "KoboToolbox"
 
         # Download attachments for each submission, if they exist
         if "_attachments" in submission:


### PR DESCRIPTION
## Goal

Closes #33. 

(This issue includes broader discussions about discoverability and cataloging that fall outside the scope of this repository. We should ensure those topics are not lost, but this PR addresses the primary request for `gc-scripts-hub`.)

## What I changed

* For KoboToolbox and CoMapeo, I added a `data_source` property.
* For alerts, I renamed `alert_source` to `data_source` for consistency. 
  * This change illustrates why "data" is a more appropriate term than "dataset", which we considered in the past: the source is variable and is bound to change over time. We know that our current alerts provider will change in the near future, but we will continue writing to the same dataset. (To wit, I also updated a TODO comment to ensure we do not overwrite the `data_source` for existing records.)
  * I also renamed `source` to `source_file_name` for clarity.
  * Minor thing but I alphabetized the list of columns to be written / updated.

## Note:

> [!IMPORTANT]
> After this is merged, I will recreate `alert` and `alert__metadata` tables in production to reflect the column renaming and schema updates.