### PR TITLE
Document decision not to share code between scripts (for now)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Note that Windmill also designates a `u/` directory for storing code per user on
 
 For information on developing scripts, see the [Windmill Scripts quickstart](https://www.windmill.dev/docs/getting_started/scripts_quickstart).
 
+While it is possible in Windmill to [share common logic across scripts with relative imports](https://www.
+windmill.dev/docs/advanced/sharing_common_logic) we have avoided doing so at this time. This decision aims to keep each script as self-contained as possible, promoting modularity and reducing interdependencies. As a trade-off, there may be some redundancy across common operations, such as writing to a database.
+
 You may develop within Windmill's code editor, or locally.  Developing locally has the advantage
 of being able to run tests.
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ Note that Windmill also designates a `u/` directory for storing code per user on
 
 For information on developing scripts, see the [Windmill Scripts quickstart](https://www.windmill.dev/docs/getting_started/scripts_quickstart).
 
-While it is possible in Windmill to [share common logic across scripts with relative imports](https://www.
-windmill.dev/docs/advanced/sharing_common_logic) we have avoided doing so at this time. This decision aims to keep each script as self-contained as possible, promoting modularity and reducing interdependencies. As a trade-off, there may be some redundancy across common operations, such as writing to a database.
+While it is possible in Windmill to [share common logic across scripts with relative imports](https://www.windmill.dev/docs/advanced/sharing_common_logic) we have avoided doing so at this time. This decision aims to keep each script as self-contained as possible, promoting modularity and reducing interdependencies. As a trade-off, there may be some redundancy across common operations, such as writing to a database.
 
 You may develop within Windmill's code editor, or locally.  Developing locally has the advantage
 of being able to run tests.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Note that Windmill also designates a `u/` directory for storing code per user on
 
 For information on developing scripts, see the [Windmill Scripts quickstart](https://www.windmill.dev/docs/getting_started/scripts_quickstart).
 
-While it is possible in Windmill to [share common logic across scripts with relative imports](https://www.windmill.dev/docs/advanced/sharing_common_logic) we have avoided doing so at this time. This decision aims to keep each script as self-contained as possible, promoting modularity and reducing interdependencies. As a trade-off, there may be some redundancy across common operations, such as writing to a database.
+While Windmill allows [sharing common logic across scripts with relative imports](https://www.windmill.dev/docs/advanced/sharing_common_logic), we have chosen to avoid this approach for now. This decision aims to keep each script as self-contained as possible, promoting modularity and reducing interdependencies. Additionally, sharing code across scripts is challenging because each script has its own dependency stack. Shared code must either work across varying dependencies or explicitly declare its own, making management cumbersome without creating a proper package. As a trade-off resulting from this decision, some redundancy may exist in common operations, such as database writes.
 
 You may develop within Windmill's code editor, or locally.  Developing locally has the advantage
 of being able to run tests.

--- a/f/connectors/alerts/alerts_gcs.py
+++ b/f/connectors/alerts/alerts_gcs.py
@@ -380,9 +380,6 @@ class AlertsDBWriter:
     Specifically tailored for operations involving geographic data and alerts metadata stored in GeoJSON format.
 
     This class manages database connections using PostgreSQL through psycopg2.
-
-    TODO: DRY with KoboDBWriter and CoMapeoDBWriter
-
     """
 
     def __init__(self, db_connection_string, table_name):


### PR DESCRIPTION
## Goal

We have discussed internally that for the time being, we will keep each script as self-contained as possible. Here I am explicitly documenting that in the repo's README.

I have also removed one TODO comment that is obviated by this decision.