### PR TITLE
Add script to post alerts to CoMapeo Cloud API

### DIFF
--- a/f/connectors/comapeo/README.md
+++ b/f/connectors/comapeo/README.md
@@ -8,9 +8,7 @@ For each project, the observations data is stored in a table prefixed by `table_
 
 The request header must include an access token in the format: Authorized: Bearer <token>.
 
-### `GET /projects`
-
-```json
+### `GET /projects````json
 {
   "data": [
     {
@@ -42,3 +40,42 @@ The request header must include an access token in the format: Authorized: Beare
 ### `GET /projects/abc123/attachments/attachment2_hash/photo/blob2_hash`
 
 This endpoint retrieves the binary data of a specific attachment, such as a photo, associated with a project. The response will contain the raw binary content of the file, which can be saved or processed as needed.
+
+# CoMapeo: Post Alerts
+
+This script fetches alerts data from a database and posts it to a CoMapeo server.
+
+## Endpoints
+
+The request header must include an access token in the format: Authorized: Bearer <token>.
+
+### `POST /projects/abc123/remoteDetecionAlerts`
+
+```json
+{
+  "detectionDateStart": "2024-11-03T04:20:69Z",
+  "detectionDateEnd": "2024-11-04T04:20:69Z",
+  "sourceId": "abc123",
+  "metadata": { "foo": "bar" },
+  "geometry": {
+    "type": "Point",
+    "coordinates": [12, 34]
+  }
+}
+# => HTTP 201, no response body
+```
+
+### `GET /projects/abc123/remoteDetectionAlerts`
+
+```json
+{
+  "detectionDateStart": "2024-11-03T04:20:69Z",
+  "detectionDateEnd": "2024-11-04T04:20:69Z",
+  "sourceId": "abc123",
+  "metadata": { "foo": "bar" },
+  "geometry": {
+    "type": "Point",
+    "coordinates": [12, 34]
+  }
+}
+```

--- a/f/connectors/comapeo/comapeo_alerts.py
+++ b/f/connectors/comapeo/comapeo_alerts.py
@@ -70,6 +70,8 @@ def get_alerts_from_db(db_connection_string, db_table_name: str):
     list
         A list of tuples, where each tuple represents an alert row from the database table.
     """
+    logger.info("Fetching alerts from database...")
+
     conn = psycopg2.connect(dsn=db_connection_string)
     cur = conn.cursor()
     cur.execute(f"SELECT * FROM {db_table_name}")
@@ -124,15 +126,25 @@ def filter_alerts(comapeo_alerts_endpoint: str, comapeo_headers: str, alerts):
     list
         A list of dictionaries, where each dictionary represents an alert that has not been posted to the CoMapeo API.
     """
+    logger.info("Filtering alerts...")
+
     alerts_posted_to_comapeo = _get_alerts_from_comapeo(
         comapeo_alerts_endpoint, comapeo_headers
     )
+    posted_source_ids = {alert["sourceId"] for alert in alerts_posted_to_comapeo}
+
+    logger.error(f"Posted source IDs: {posted_source_ids}")
+    logger.error(f"Alerts: {alerts}")
 
     # alert_id in the database matches sourceId on CoMapeo
-    posted_source_ids = {alert["sourceId"] for alert in alerts_posted_to_comapeo}
     unposted_alerts = [
-        alert for alert in alerts if alert["alert_id"] not in posted_source_ids
+        alert
+        for alert in alerts
+        if alert[0]
+        not in posted_source_ids  # Assuming alert_id is the first element of the tuple
     ]
+
+    logger.info(f"Unposted alerts: {unposted_alerts}")
 
     return unposted_alerts
 

--- a/f/connectors/comapeo/comapeo_alerts.py
+++ b/f/connectors/comapeo/comapeo_alerts.py
@@ -1,0 +1,167 @@
+# requirements:
+# psycopg2-binary
+# requests~=2.32
+
+import json
+import logging
+from typing import TypedDict
+
+import psycopg2
+import requests
+
+# type names that refer to Windmill Resources
+postgresql = dict
+
+
+class comapeo_server(TypedDict):
+    server_url: str
+    access_token: str
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def conninfo(db: postgresql):
+    """Convert a `postgresql` Windmill Resources to psycopg-style connection string"""
+    # password is optional
+    password_part = f" password={db['password']}" if "password" in db else ""
+    conn = "dbname={dbname} user={user} host={host} port={port}".format(**db)
+    return conn + password_part
+
+
+def main(
+    db: postgresql,
+    comapeo: comapeo_server,
+    comapeo_project: str,
+    db_table_name: str = "alerts",
+):
+    comapeo_server_url = comapeo["server_url"]
+    comapeo_alerts_endpoint = (
+        f"{comapeo_server_url}/projects/{comapeo_project}/remoteDetectionAlerts"
+    )
+
+    comapeo_access_token = comapeo["access_token"]
+    comapeo_headers = {
+        "Authorization": f"Bearer {comapeo_access_token}",
+        "Content-Type": "application/json",
+    }
+
+    alerts = get_alerts_from_db(conninfo(db), db_table_name)
+
+    unposted_alerts = filter_alerts(comapeo_alerts_endpoint, comapeo_headers, alerts)
+
+    post_alerts(comapeo_alerts_endpoint, comapeo_headers, unposted_alerts)
+
+
+def get_alerts_from_db(db_connection_string, db_table_name: str):
+    """
+    Retrieves alerts from a PostgreSQL database table.
+
+    Parameters
+    ----------
+    db_connection_string : str
+        The connection string for the PostgreSQL database.
+    db_table_name : str
+        The name of the database table containing the alerts.
+
+    Returns
+    -------
+    list
+        A list of tuples, where each tuple represents an alert row from the database table.
+    """
+    conn = psycopg2.connect(dsn=db_connection_string)
+    cur = conn.cursor()
+    cur.execute(f"SELECT * FROM {db_table_name}")
+    alerts = cur.fetchall()
+    cur.close()
+    conn.close()
+    return alerts
+
+
+def _get_alerts_from_comapeo(comapeo_alerts_endpoint: str, comapeo_headers: str):
+    """
+    Fetches alerts from the CoMapeo API.
+
+    Parameters
+    ----------
+    comapeo_alerts_endpoint : str
+        The URL endpoint for retrieving alerts from the CoMapeo API.
+    comapeo_headers : str
+        The headers to be included in the API request, such as authorization tokens.
+
+    Returns
+    -------
+    list
+        A list of dictionaries, where each dictionary represents an alert retrieved from the CoMapeo API.
+    """
+    logger.info("Fetching alerts from CoMapeo API...")
+    response = requests.request(
+        "GET", url=comapeo_alerts_endpoint, headers=comapeo_headers, data={}
+    )
+
+    response.raise_for_status()
+    alerts = response.json().get("data", [])
+
+    return alerts
+
+
+def filter_alerts(comapeo_alerts_endpoint: str, comapeo_headers: str, alerts):
+    """
+    Filters a list of alerts to find those that have not been posted to the CoMapeo API.
+
+    Parameters
+    ----------
+    comapeo_alerts_endpoint : str
+        The URL endpoint for retrieving alerts from the CoMapeo API.
+    comapeo_headers : str
+        The headers to be included in the API request, such as authorization tokens.
+    alerts : list
+        A list of dictionaries, where each dictionary represents an alert.
+
+    Returns
+    -------
+    list
+        A list of dictionaries, where each dictionary represents an alert that has not been posted to the CoMapeo API.
+    """
+    alerts_posted_to_comapeo = _get_alerts_from_comapeo(
+        comapeo_alerts_endpoint, comapeo_headers
+    )
+
+    # alert_id in the database matches sourceId on CoMapeo
+    posted_source_ids = {alert["sourceId"] for alert in alerts_posted_to_comapeo}
+    unposted_alerts = [
+        alert for alert in alerts if alert["alert_id"] not in posted_source_ids
+    ]
+
+    return unposted_alerts
+
+
+def post_alerts(
+    comapeo_alerts_endpoint: str,
+    comapeo_headers: str,
+    unposted_alerts,
+):
+    """
+    Posts a list of alerts to the CoMapeo API.
+
+    Parameters
+    ----------
+    comapeo_alerts_endpoint : str
+        The URL endpoint for posting alerts to the CoMapeo API.
+    comapeo_headers : str
+        The headers to be included in the API request, such as authorization tokens.
+    unposted_alerts : list
+        A list of dictionaries, where each dictionary represents an alert to be posted to the CoMapeo API.
+    """
+    logger.info("Posting alerts to CoMapeo API...")
+
+    for alert in unposted_alerts:
+        payload = json.dumps(alert)
+        response = requests.request(
+            "POST", url=comapeo_alerts_endpoint, headers=comapeo_headers, data=payload
+        )
+        response.raise_for_status()
+        logger.info(f"Posted alert: {alert}")
+
+    logger.info("All alerts posted successfully.")

--- a/f/connectors/comapeo/comapeo_alerts.py
+++ b/f/connectors/comapeo/comapeo_alerts.py
@@ -133,9 +133,6 @@ def filter_alerts(comapeo_alerts_endpoint: str, comapeo_headers: str, alerts):
     )
     posted_source_ids = {alert["sourceId"] for alert in alerts_posted_to_comapeo}
 
-    logger.error(f"Posted source IDs: {posted_source_ids}")
-    logger.error(f"Alerts: {alerts}")
-
     # alert_id in the database matches sourceId on CoMapeo
     unposted_alerts = [
         alert

--- a/f/connectors/comapeo/comapeo_alerts.script.lock
+++ b/f/connectors/comapeo/comapeo_alerts.script.lock
@@ -1,0 +1,2 @@
+psycopg2-binary==2.9.10
+requests==2.32.3

--- a/f/connectors/comapeo/comapeo_alerts.script.yaml
+++ b/f/connectors/comapeo/comapeo_alerts.script.yaml
@@ -1,0 +1,40 @@
+summary: 'CoMapeo: Post Alerts'
+description: This script fetches alerts data from a database and posts it to a CoMapeo server.
+lock: '!inline f/connectors/comapeo/comapeo_alerts.script.lock'
+concurrency_time_window_s: 0
+kind: script
+schema:
+  $schema: 'https://json-schema.org/draft/2020-12/schema'
+  type: object
+  order:
+    - db
+    - db_table_name
+    - comapeo
+    - comapeo_project
+  properties:
+    comapeo:
+      type: object
+      description: A server URL and access token pair to connect to a CoMapeo archive server.
+      default: null
+      format: resource-comapeo_server
+    comapeo_project:
+      type: string
+      description: A project ID on the CoMapeo server where the alerts will be posted.
+      default: null
+      originalType: string
+    db:
+      type: object
+      description: A database connection for fetching alerts data.
+      default: null
+      format: resource-postgresql
+    db_table_name:
+      type: string
+      description: The name of the database table where alerts data is stored.
+      default: "alerts"
+      originalType: string
+      pattern: '^.{1,54}$'
+  required:
+    - db
+    - db_table_name
+    - comapeo
+    - comapeo_project

--- a/f/connectors/comapeo/tests/assets/server_responses.py
+++ b/f/connectors/comapeo/tests/assets/server_responses.py
@@ -63,3 +63,17 @@ def comapeo_project_observations(uri, project_id):
             },
         ]
     }
+
+
+def comapeo_alerts():
+    return {
+        "data": [
+            {
+                "detectionDateStart": "2024-11-03T04:20:69Z",
+                "detectionDateEnd": "2024-11-04T04:20:69Z",
+                "sourceId": "abc123",
+                "metadata": {"foo": "bar"},
+                "geometry": {"type": "Point", "coordinates": [12, 34]},
+            }
+        ]
+    }

--- a/f/connectors/comapeo/tests/comapeo_alerts_test.py
+++ b/f/connectors/comapeo/tests/comapeo_alerts_test.py
@@ -16,8 +16,8 @@ class Alert(NamedTuple):
 @pytest.fixture
 def fake_alerts_table(pg_database):
     alerts = [
-        Alert("abc123", "Hello, world!"),
-        Alert("def456", "Goodbye, world!"),
+        Alert("abc123", "gold_mining"),
+        Alert("def456", "illegal_fishing"),
     ]
 
     conn = psycopg2.connect(**pg_database)
@@ -28,9 +28,9 @@ def fake_alerts_table(pg_database):
         cur.execute("""
             CREATE TABLE fake_alerts (
                 alert_id TEXT PRIMARY KEY,
-                alert_message TEXT
+                alert_type TEXT
             )
-        """)
+        """)  # there are more alert columns than these, but it is not necessary for this test to include them
 
         values = [(a.alert_id, a.alert_message) for a in alerts]
         cur.executemany("INSERT INTO fake_alerts VALUES (%s, %s)", values)

--- a/f/connectors/comapeo/tests/comapeo_alerts_test.py
+++ b/f/connectors/comapeo/tests/comapeo_alerts_test.py
@@ -1,0 +1,45 @@
+from typing import NamedTuple
+
+import pytest
+
+from f.connectors.comapeo.comapeo_alerts import (
+    main,
+)
+
+
+class Alert(NamedTuple):
+    alert_id: str
+    alert_message: str
+
+
+@pytest.fixture
+def fake_alerts_table(pg_database):
+    alerts = [
+        Alert("abc123", "Hello, world!"),
+        Alert("def456", "Goodbye, world!"),
+    ]
+
+    with pg_database.cursor() as cur:
+        cur.execute("""
+            CREATE TEMPORARY TABLE fake_alerts (
+                alert_id TEXT PRIMARY KEY,
+                alert_message TEXT
+            )
+        """)
+
+        values = [(a.alert_id, a.alert_message) for a in alerts]
+        cur.executemany("INSERT INTO fake_alerts VALUES (%s, %s)", values)
+
+    return alerts
+
+
+def test_script_e2e(comapeoserver_alerts, pg_database, fake_alerts_table):
+    main(
+        pg_database,
+        comapeoserver_alerts.comapeo_server,
+        "forest_expedition",
+        "fake_alerts",
+    )
+
+    expected_alerts = set(a.alert_id for a in fake_alerts_table)
+    assert expected_alerts == set(comapeoserver_alerts.posted_alerts)

--- a/f/connectors/comapeo/tests/comapeo_observations_test.py
+++ b/f/connectors/comapeo/tests/comapeo_observations_test.py
@@ -42,12 +42,12 @@ def test_normalize_and_snakecase_keys():
     assert result == expected_output, f"Expected {expected_output}, but got {result}"
 
 
-def test_script_e2e(comapeoserver, pg_database, tmp_path):
+def test_script_e2e(comapeoserver_observations, pg_database, tmp_path):
     asset_storage = tmp_path / "datalake"
 
     main(
-        comapeoserver.comapeo_server,
-        comapeoserver.comapeo_project_blocklist,
+        comapeoserver_observations.comapeo_server,
+        comapeoserver_observations.comapeo_project_blocklist,
         pg_database,
         "comapeo",
         asset_storage,

--- a/f/connectors/comapeo/tests/conftest.py
+++ b/f/connectors/comapeo/tests/conftest.py
@@ -63,23 +63,24 @@ def comapeoserver_alerts(mocked_responses):
         comapeo_server: dict
 
     server_url = "http://comapeo.example.org"
-    access_token = "MapYourWorldTogether!"
     project_id = "forest_expedition"
+    comapeo_alerts_endpoint = (
+        f"{server_url}/projects/{project_id}/remoteDetectionAlerts"
+    )
+    access_token = "MapYourWorldTogether!"
 
     mocked_responses.get(
-        f"{server_url}/projects/{project_id}/remoteDetectionAlerts",
+        comapeo_alerts_endpoint,
         json=server_responses.comapeo_alerts(),
         status=201,
     )
 
     mocked_responses.post(
-        f"{server_url}/projects/{project_id}/remoteDetectionAlerts",
+        comapeo_alerts_endpoint,
         status=201,
     )
 
-    server: comapeo_server = dict(
-        comapeo_alerts_endpoint=server_url, access_token=access_token
-    )
+    server: comapeo_server = dict(server_url=server_url, access_token=access_token)
 
     return CoMapeoServer(
         server,

--- a/f/connectors/comapeo/tests/conftest.py
+++ b/f/connectors/comapeo/tests/conftest.py
@@ -5,8 +5,8 @@ import pytest
 import responses
 import testing.postgresql
 
-from f.connectors.comapeo.tests.assets import server_responses
 from f.connectors.comapeo.comapeo_observations import comapeo_server
+from f.connectors.comapeo.tests.assets import server_responses
 
 
 @pytest.fixture
@@ -16,7 +16,7 @@ def mocked_responses():
 
 
 @pytest.fixture
-def comapeoserver(mocked_responses):
+def comapeoserver_observations(mocked_responses):
     """A mock CoMapeo Server that you can use to provide projects and their observations"""
 
     @dataclass
@@ -51,6 +51,38 @@ def comapeoserver(mocked_responses):
     return CoMapeoServer(
         server,
         comapeo_project_blocklist,
+    )
+
+
+@pytest.fixture
+def comapeoserver_alerts(mocked_responses):
+    """A mock CoMapeo Server that you can use to get and post alerts"""
+
+    @dataclass
+    class CoMapeoServer:
+        comapeo_server: dict
+
+    server_url = "http://comapeo.example.org"
+    access_token = "MapYourWorldTogether!"
+    project_id = "forest_expedition"
+
+    mocked_responses.get(
+        f"{server_url}/projects/{project_id}/remoteDetectionAlerts",
+        json=server_responses.comapeo_alerts(),
+        status=201,
+    )
+
+    mocked_responses.post(
+        f"{server_url}/projects/{project_id}/remoteDetectionAlerts",
+        status=201,
+    )
+
+    server: comapeo_server = dict(
+        comapeo_alerts_endpoint=server_url, access_token=access_token
+    )
+
+    return CoMapeoServer(
+        server,
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-env_list = alerts, comapeo_observations, kobotoolbox_responses, postgres_to_geojson
+env_list = alerts, comapeo, kobotoolbox_responses, postgres_to_geojson
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -22,9 +22,10 @@ environment =
 expose =
     TOX_DOCKER_GCS_PORT=10010/tcp
 
-[testenv:comapeo_observations]
+[testenv:comapeo]
 deps =
     -r{toxinidir}/f/connectors/comapeo/comapeo_observations.script.lock
+    -r{toxinidir}/f/connectors/comapeo/comapeo_alerts.script.lock
     -r{toxinidir}/f/connectors/comapeo/tests/requirements-test.txt
 commands =
     pytest {posargs} f/connectors/comapeo


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-scripts-hub/issues/28.

> [!NOTE]
> This code will not yet work in production, because it depends on https://github.com/digidem/comapeo-cloud/pull/41 being merged and a new CoMapeo Docker image being published and deployed.

## What I changed

* I added a `comapeo_alerts` script that performs the following tasks:
  - Retrieves alerts from the database.
  - Fetches alerts from the CoMapeo server.
  - Filters the database alerts against the alerts from the CoMapeo server to create a list of unposted alerts.
  - Posts the unposted alerts to the CoMapeo server.
* I added a e2e test that uses a mock CoMapeo server with GET and POST alerts endpoints, along with a server response fixture containing one existing alert, to simulate posting an unposted alert.

## Notes

In implementing this, I sought fit to turn this into its own script apart from `alerts_gcs` to maintain clean code and ensure separation of concerns. 

However, this approach introduces a sequence issue: **when scheduled in production, this script should run after `alerts_gcs` has successfully ingested a new batch of alerts**. While we can make a reasonable estimate of when to schedule this based on existing `alerts_gcs` run data across our Windmill instances, this approach is not deterministic and could encounter edge cases where an `alerts_gcs` run takes significantly longer than expected due to issues with GCP upstream.

This is further complicated by the fact we have a _third_ operation in the sequence: https://github.com/ConservationMetrics/gc-scripts-hub/pull/59 aims to send a Twilio message to recipients about new alerts. https://github.com/ConservationMetrics/gc-scripts-hub/pull/59 adds this operation to the `alerts_gcs` script, but arguably, a message to recipients about new alerts should not be sent until _both_ scripts have run: a CoMapeo user in the field can then know to synchronize, to see the new alerts on CoMapeo right away.

This leads me to think there are two options:

1. We have one giant script to rule them all, and chains a sequence of (a) alerts ETL, (b) post alerts to CoMapeo, (c) send Twilio message. In doing so we can separate the respective logic for each into separate files lacking a `main` function, but are imported into one that does.
2. We chain the scripts together using a Windmill Flow. But as mentioned in https://github.com/ConservationMetrics/gc-scripts-hub/pull/59:
    > This will increase the burden on our envisioned "operator" users, as they will need to understand an additional Windmill concept (and all that it entails—such as Directed Acyclic Graphs mentioned in the very first paragraph of the Windmill documentation explaining what a Flow is) and configure additional screens. 

Opinions welcome.