### PR TITLE
Create `territory_id` column in alerts metadata table as bigint

### DIFF
--- a/f/connectors/alerts/alerts_gcs.py
+++ b/f/connectors/alerts/alerts_gcs.py
@@ -431,7 +431,7 @@ class AlertsDBWriter:
                     confidence real,
                     description_alerts text,
                     month bigint,
-                    territory_id text,
+                    territory_id bigint,
                     total_alerts bigint,
                     type_alert bigint,
                     year bigint,


### PR DESCRIPTION
## Goal

I noticed that `_safe_insert()` was updating every single `alerts__metadata` row, despite the values not changing. 

The issue is that `territory_id` is being created as a text column, when the incoming value is a number. `territory_id` will always be an integer so we're making this consistent with other alerts number columns.

We will have to change the data structures of all `alerts__metadata` tables accordingly after this merge. (I will do so.)