### PR TITLE
Improve the CoMapeo alert script for runtime Windmill usage

### DIFF
--- a/f/connectors/comapeo/comapeo_alerts.py
+++ b/f/connectors/comapeo/comapeo_alerts.py
@@ -52,6 +52,10 @@ def main(
 
     unposted_alerts = filter_alerts(comapeo_alerts_endpoint, comapeo_headers, alerts)
 
+    if not unposted_alerts:
+        logger.info("No new alerts to post!")
+        return
+
     transformed_unposted_alerts = transform_alerts(unposted_alerts)
 
     post_alerts(comapeo_alerts_endpoint, comapeo_headers, transformed_unposted_alerts)
@@ -83,6 +87,9 @@ def get_alerts_from_db(db_connection_string, db_table_name: str):
     ]
     cur.close()
     conn.close()
+
+    logger.info(f"{len(alerts)} alerts found in database.")
+
     return alerts
 
 
@@ -112,6 +119,7 @@ def _get_alerts_from_comapeo(comapeo_alerts_endpoint: str, comapeo_headers: dict
 
     posted_alert_source_ids = {alert["sourceId"] for alert in alerts}
 
+    logger.info(f"{len(posted_alert_source_ids)} alerts found on CoMapeo.")
     return posted_alert_source_ids
 
 
@@ -148,6 +156,7 @@ def filter_alerts(
         if alert.get("alert_id") not in alerts_posted_to_comapeo
     ]
 
+    logger.info(f"{len(unposted_alerts)} alerts in database not yet posted to CoMapeo.")
     return unposted_alerts
 
 

--- a/f/connectors/comapeo/comapeo_alerts.py
+++ b/f/connectors/comapeo/comapeo_alerts.py
@@ -179,13 +179,13 @@ def transform_alerts(alerts: list[dict]):
     transformed_alerts = [
         {
             # CoMapeo API requires these to be ISO 8601 datetime format
-            "detectionDateStart": datetime.strptime(
-                alert["date_start_t0"], "%Y-%m-%d"
-            ).isoformat(timespec="seconds")
+            "detectionDateStart": datetime.strptime(alert["date_start_t0"], "%Y-%m-%d")
+            .replace(hour=15, minute=0, second=0)
+            .isoformat(timespec="seconds")
             + "Z",
-            "detectionDateEnd": datetime.strptime(
-                alert["date_end_t0"], "%Y-%m-%d"
-            ).isoformat(timespec="seconds")
+            "detectionDateEnd": datetime.strptime(alert["date_end_t0"], "%Y-%m-%d")
+            .replace(hour=15, minute=0, second=0)
+            .isoformat(timespec="seconds")
             + "Z",
             "geometry": {
                 "type": alert["g__type"],

--- a/f/connectors/comapeo/comapeo_alerts.py
+++ b/f/connectors/comapeo/comapeo_alerts.py
@@ -178,7 +178,7 @@ def transform_alerts(alerts: list[dict]):
 
     transformed_alerts = [
         {
-            # CoMapeo API requires these to be ISO 8601 format
+            # CoMapeo API requires these to be ISO 8601 datetime format
             "detectionDateStart": datetime.strptime(
                 alert["date_start_t0"], "%Y-%m-%d"
             ).isoformat(timespec="seconds")

--- a/f/connectors/comapeo/comapeo_alerts.py
+++ b/f/connectors/comapeo/comapeo_alerts.py
@@ -2,7 +2,9 @@
 # psycopg2-binary
 # requests~=2.32
 
+import json
 import logging
+from datetime import datetime
 from typing import TypedDict
 
 import psycopg2
@@ -50,7 +52,9 @@ def main(
 
     unposted_alerts = filter_alerts(comapeo_alerts_endpoint, comapeo_headers, alerts)
 
-    post_alerts(comapeo_alerts_endpoint, comapeo_headers, unposted_alerts)
+    transformed_unposted_alerts = transform_alerts(unposted_alerts)
+
+    post_alerts(comapeo_alerts_endpoint, comapeo_headers, transformed_unposted_alerts)
 
 
 def get_alerts_from_db(db_connection_string, db_table_name: str):
@@ -82,7 +86,7 @@ def get_alerts_from_db(db_connection_string, db_table_name: str):
     return alerts
 
 
-def _get_alerts_from_comapeo(comapeo_alerts_endpoint: str, comapeo_headers: str):
+def _get_alerts_from_comapeo(comapeo_alerts_endpoint: str, comapeo_headers: dict):
     """
     Fetches alerts from the CoMapeo API.
 
@@ -90,7 +94,7 @@ def _get_alerts_from_comapeo(comapeo_alerts_endpoint: str, comapeo_headers: str)
     ----------
     comapeo_alerts_endpoint : str
         The URL endpoint for retrieving alerts from the CoMapeo API.
-    comapeo_headers : str
+    comapeo_headers : dict
         The headers to be included in the API request, such as authorization tokens.
 
     Returns
@@ -147,10 +151,51 @@ def filter_alerts(
     return unposted_alerts
 
 
+def transform_alerts(alerts: list[dict]):
+    """
+    Transforms a list of alerts into a format that can be posted to the CoMapeo API.
+
+    Parameters
+    ----------
+    alerts : list[dict]
+        A list of dictionaries, where each dictionary represents an alert.
+
+    Returns
+    -------
+    list[dict]
+        A list of dictionaries, where each dictionary represents an alert in a format that can be posted to the CoMapeo API.
+    """
+    logger.info("Transforming alerts...")
+
+    transformed_alerts = [
+        {
+            "detectionDateStart": datetime.strptime(
+                alert["date_start_t0"], "%Y-%m-%d"
+            ).isoformat(timespec="seconds")
+            + "Z",
+            "detectionDateEnd": datetime.strptime(
+                alert["date_end_t0"], "%Y-%m-%d"
+            ).isoformat(timespec="seconds")
+            + "Z",
+            "geometry": {
+                "type": alert["g__type"],
+                "coordinates": json.loads(alert["g__coordinates"]),
+            },
+            "metadata": {
+                "alert_type": alert["alert_type"],
+            },
+            "sourceId": alert["alert_id"],
+        }
+        for alert in alerts
+    ]
+
+    return transformed_alerts
+
+
 def post_alerts(
     comapeo_alerts_endpoint: str,
-    comapeo_headers: str,
-    unposted_alerts,
+    comapeo_headers: dict,
+    alerts: list[dict],
 ):
     """
     Posts a list of alerts to the CoMapeo API.
@@ -159,17 +204,17 @@ def post_alerts(
     ----------
     comapeo_alerts_endpoint : str
         The URL endpoint for posting alerts to the CoMapeo API.
-    comapeo_headers : str
+    comapeo_headers : dict
         The headers to be included in the API request, such as authorization tokens.
-    unposted_alerts : list
+    alerts : list[dict]
         A list of dictionaries, where each dictionary represents an alert to be posted to the CoMapeo API.
     """
     logger.info("Posting alerts to CoMapeo API...")
 
-    for alert in unposted_alerts:
+    for alert in alerts:
         response = requests.post(
             url=comapeo_alerts_endpoint, headers=comapeo_headers, json=alert
         )
         response.raise_for_status()
 
-    logger.info(f"{len(unposted_alerts)} alerts posted successfully.")
+    logger.info(f"{len(alerts)} alerts posted successfully.")

--- a/f/connectors/comapeo/comapeo_alerts.py
+++ b/f/connectors/comapeo/comapeo_alerts.py
@@ -162,7 +162,7 @@ def filter_alerts(
 
 def transform_alerts(alerts: list[dict]):
     """
-    Transforms a list of alerts into a format that can be posted to the CoMapeo API.
+    Transforms a list of alerts into a format that matches the expected schema on the CoMapeo API.
 
     Parameters
     ----------
@@ -178,6 +178,7 @@ def transform_alerts(alerts: list[dict]):
 
     transformed_alerts = [
         {
+            # CoMapeo API requires these to be ISO 8601 format
             "detectionDateStart": datetime.strptime(
                 alert["date_start_t0"], "%Y-%m-%d"
             ).isoformat(timespec="seconds")

--- a/f/connectors/comapeo/comapeo_alerts.script.lock
+++ b/f/connectors/comapeo/comapeo_alerts.script.lock
@@ -1,5 +1,6 @@
-certifi==2024.8.30
+certifi==2024.12.14
+charset-normalizer==3.4.1
 idna==3.10
 psycopg2-binary==2.9.10
 requests==2.32.3
-urllib3==2.2.3
+urllib3==2.3.0

--- a/f/connectors/comapeo/comapeo_alerts.script.lock
+++ b/f/connectors/comapeo/comapeo_alerts.script.lock
@@ -1,2 +1,5 @@
+certifi==2024.8.30
+idna==3.10
 psycopg2-binary==2.9.10
 requests==2.32.3
+urllib3==2.2.3

--- a/f/connectors/comapeo/comapeo_observations.script.lock
+++ b/f/connectors/comapeo/comapeo_observations.script.lock
@@ -1,6 +1,6 @@
-certifi==2024.8.30
-charset-normalizer==3.4.0
+certifi==2024.12.14
+charset-normalizer==3.4.1
 idna==3.10
 psycopg2-binary==2.9.10
 requests==2.32.3
-urllib3==2.2.3
+urllib3==2.3.0

--- a/f/connectors/comapeo/tests/comapeo_alerts_test.py
+++ b/f/connectors/comapeo/tests/comapeo_alerts_test.py
@@ -10,14 +10,27 @@ from f.connectors.comapeo.comapeo_alerts import (
 
 class Alert(NamedTuple):
     alert_id: str
-    alert_message: str
+    alert_type: str
+    g__type: str
+    g__coordinates: tuple[float, float]
+    date_start_t0: str
+    date_end_t0: str
 
 
 @pytest.fixture
 def fake_alerts_table(pg_database):
     alerts = [
-        Alert("abc123", "gold_mining"),
-        Alert("def456", "illegal_fishing"),
+        Alert(
+            "abc123", "gold_mining", "Point", "[12.0, 34.0]", "2023-01-01", "2023-01-02"
+        ),
+        Alert(
+            "def456",
+            "illegal_fishing",
+            "Point",
+            "[56.0, 78.0]",
+            "2023-02-01",
+            "2023-02-02",
+        ),
     ]
 
     conn = psycopg2.connect(**pg_database)
@@ -28,12 +41,28 @@ def fake_alerts_table(pg_database):
         cur.execute("""
             CREATE TABLE fake_alerts (
                 alert_id TEXT PRIMARY KEY,
-                alert_type TEXT
+                alert_type TEXT,
+                g__type TEXT,
+                g__coordinates TEXT,
+                date_start_t0 TEXT,
+                date_end_t0 TEXT
             )
-        """)  # there are more alert columns than these, but it is not necessary for this test to include them
+        """)
 
-        values = [(a.alert_id, a.alert_message) for a in alerts]
-        cur.executemany("INSERT INTO fake_alerts VALUES (%s, %s)", values)
+        values = [
+            (
+                a.alert_id,
+                a.alert_type,
+                a.g__type,
+                a.g__coordinates,
+                a.date_start_t0,
+                a.date_end_t0,
+            )
+            for a in alerts
+        ]
+        cur.executemany(
+            "INSERT INTO fake_alerts VALUES (%s, %s, %s, %s, %s, %s)", values
+        )
 
         yield alerts
     finally:
@@ -50,4 +79,7 @@ def test_script_e2e(comapeoserver_alerts, pg_database, fake_alerts_table):
     )
 
     expected_alerts = set(a.alert_id for a in fake_alerts_table)
-    assert expected_alerts == {"def456", "abc123"}
+    assert expected_alerts == {
+        "def456",
+        "abc123",
+    }  # abc123 already exists on the CoMapeo server


### PR DESCRIPTION
## Goal

Now that the CoMapeo Cloud server has the `GET projects/:projectId/remoteDetectionAlerts` endpoint that we needed, and I could deploy a new image for testing, I found that some improvements were needed for Windmill runtime usage of the CoMapeo alerts script.

## Screenshots

![image](https://github.com/user-attachments/assets/fb0ec8f8-be1e-4f8b-9c8d-53b49830f5a2)

## What I changed

* Added missing Python requirements added to `comapeo_alerts.script.lock`
* The CoMapeo server expects remote detection alerts in a typed schema, so I added a function to transform alerts to be consistent with that schema. And adapted the tests to reflect this new behavior.
* Minor improvements to logging for clarity, and a few type annotation corrections.