### PR TITLE
Document the need for maintaining consistent versions of deps across the test environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ To run tests for only one folder, specify the folder as an `-e «environment»` 
 
     tox -e alerts
 
+Note that the versions of package dependencies must be the same for scripts across a tox environment,
+or you will get an error about conflicting dependencies.
 
 # Running Windmill
 


### PR DESCRIPTION
Else, you get this kind of error:

```
ERROR: Cannot install certifi==2024.12.14 and certifi==2024.8.30 because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```