### PR TITLE
Remove "frizzle" prefix from persistent storage paths

### DIFF
--- a/f/connectors/alerts/alerts_gcs.py
+++ b/f/connectors/alerts/alerts_gcs.py
@@ -44,7 +44,7 @@ def main(
     territory_id: int,
     db: postgresql,
     db_table_name: str,
-    destination_path: str = "/frizzle-persistent-storage/datalake/change_detection/alerts",
+    destination_path: str = "/persistent-storage/datalake/change_detection/alerts",
 ):
     """
     Wrapper around _main() that instantiates the GCP client.

--- a/f/connectors/alerts/alerts_gcs.script.yaml
+++ b/f/connectors/alerts/alerts_gcs.script.yaml
@@ -35,7 +35,7 @@ schema:
       description: >-
         A string specifying the local directory path where files will be
         downloaded and processed.
-      default: /frizzle-persistent-storage/datalake/change_detection/alerts
+      default: /persistent-storage/datalake/change_detection/alerts
       originalType: string
     gcp_service_acct:
       type: object

--- a/f/connectors/comapeo/comapeo_observations.py
+++ b/f/connectors/comapeo/comapeo_observations.py
@@ -39,7 +39,7 @@ def main(
     comapeo_project_blocklist: list,
     db: postgresql,
     db_table_prefix: str = "comapeo",
-    attachment_root: str = "/frizzle-persistent-storage/datalake",
+    attachment_root: str = "/persistent-storage/datalake",
 ):
     server_url = comapeo["server_url"]
     access_token = comapeo["access_token"]

--- a/f/connectors/comapeo/comapeo_observations.script.yaml
+++ b/f/connectors/comapeo/comapeo_observations.script.yaml
@@ -19,7 +19,7 @@ schema:
         A path where CoMapeo attachments will be stored. Attachment files (e.g.,
         photos and audio) will be stored in the following directory schema: 
         `{attachment_root}/comapeo/my_mapeo_project/attachments/...`
-      default: /frizzle-persistent-storage/datalake
+      default: /persistent-storage/datalake
       originalType: string
     comapeo:
       type: object

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -33,7 +33,7 @@ def main(
     form_id: str,
     db: postgresql,
     db_table_name: str,
-    attachment_root: str = "/frizzle-persistent-storage/datalake",
+    attachment_root: str = "/persistent-storage/datalake",
 ):
     kobo_server_base_url = kobotoolbox["server_url"]
     kobo_api_key = kobotoolbox["api_key"]

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.script.yaml
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.script.yaml
@@ -19,7 +19,7 @@ schema:
         A path where KoboToolbox attachments will be stored. Attachment
         files will be stored in the following directory schema: 
         `{attachment_root}/{db_table_name}/attachments/{filename}`
-      default: /frizzle-persistent-storage/datalake
+      default: /persistent-storage/datalake
       originalType: string
     db:
       type: object

--- a/f/connectors/locusmap/README.md
+++ b/f/connectors/locusmap/README.md
@@ -17,10 +17,10 @@ curl -X POST \
   -H 'Authorization: Bearer Your_Access_Token' \
   -H 'Content-Type: application/json' \
   -d '{
-    "db": "$res:f/frizzle/bcmdemo_db",
+    "db": "$res:f/connectors/bcmdemo_db",
     "db_table_name": "my_locusmap_points",
-    "locusmap_tmp_path": "/frizzle-persistent-storage/tmp/Favorites.zip",
-    "attachment_root": "/frizzle-persistent-storage/datalake"
+    "locusmap_tmp_path": "/persistent-storage/tmp/Favorites.zip",
+    "attachment_root": "/persistent-storage/datalake"
 }
 # => HTTP 201, no response body
 ``` 

--- a/f/connectors/locusmap/locusmap.py
+++ b/f/connectors/locusmap/locusmap.py
@@ -31,7 +31,7 @@ def main(
     db: postgresql,
     db_table_name: str,
     locusmap_export_path: str,
-    attachment_root: str = "/frizzle-persistent-storage/datalake/",
+    attachment_root: str = "/persistent-storage/datalake/",
     delete_locusmap_export_file: bool = False,
 ):
     if Path(locusmap_export_path).suffix.lower() in [".zip", ".kmz"]:

--- a/f/connectors/locusmap/locusmap.script.yaml
+++ b/f/connectors/locusmap/locusmap.script.yaml
@@ -19,7 +19,7 @@ schema:
         A path where Locus Map attachments will be stored. Attachment
         files will be stored in the following directory schema: 
         `{attachment_root}/{db_table_name}/attachments/{filename}`
-      default: /frizzle-persistent-storage/datalake
+      default: /persistent-storage/datalake
       originalType: string
     db:
       type: object

--- a/f/export/postgres_to_geojson/postgres_to_geojson.py
+++ b/f/export/postgres_to_geojson/postgres_to_geojson.py
@@ -3,10 +3,9 @@
 
 import json
 import logging
-
 from pathlib import Path
 
-from psycopg2 import sql, connect, Error
+from psycopg2 import Error, connect, sql
 
 # type names that refer to Windmill Resources
 postgresql = dict
@@ -26,7 +25,7 @@ def conninfo(db: postgresql):
 def main(
     db: postgresql,
     db_table_name: str,
-    storage_path: str = "/frizzle-persistent-storage/datalake/export",
+    storage_path: str = "/persistent-storage/datalake/export",
 ):
     data = fetch_data_from_postgres(conninfo(db), db_table_name)
 

--- a/f/export/postgres_to_geojson/postgres_to_geojson.script.yaml
+++ b/f/export/postgres_to_geojson/postgres_to_geojson.script.yaml
@@ -29,7 +29,7 @@ schema:
       description: >-
         The path to the directory where the GeoJSON file will be stored. The
         file will be named after the database table name.
-      default: /frizzle-persistent-storage/datalake/exports
+      default: /persistent-storage/datalake/exports
       originalType: string
   required:
     - db


### PR DESCRIPTION
## Goal

In tandem with https://github.com/ConservationMetrics/gc-forge/pull/47 and responding to the [edge case](https://github.com/ConservationMetrics/gc-forge/issues/43#issuecomment-2632536556) that emerges from making that change, the goal here is to remove reference to frizzle in persistent storage paths. Then we can be done with this issue once in for all in our codebases.

I'm sufficiently motivated to make the change in our handful of community deployments too, for the sake of consistency.
