### PR TITLE
Add alerts Flow to run the three alerts scripts in sequential order (with skip logic)

### DIFF
--- a/f/connectors/alerts/README.md
+++ b/f/connectors/alerts/README.md
@@ -50,5 +50,5 @@ Currently, we are assuming there to be only four raster images for each change d
 This script leverages Twilio to send a WhatsApp message to recipients with a summary of the latest processed alerts. Below is the message template, with values from an `alerts_statistics` object:
 
 ```javascript
-`${total_alerts} new change detection alert(s) have been published on your alerts dashboard for the date of ${month_year}. The following activities have been detected in your region: ${description_alerts}. Visit your alerts dashboard here: https://explorer.${community_slug}.guardianconnector.net/alerts/alerts`
+`${total_alerts} new change detection alert(s) have been published on your alerts dashboard for the date of ${month_year}. The following activities have been detected in your region: ${description_alerts}. Visit your alerts dashboard here: https://explorer.${community_slug}.guardianconnector.net/alerts/alerts. If you are using CoMapeo with an archive server enabled, you can receive the alerts by synchronizing.`
 ```

--- a/f/connectors/alerts/README.md
+++ b/f/connectors/alerts/README.md
@@ -52,3 +52,5 @@ This script leverages Twilio to send a WhatsApp message to recipients with a sum
 ```javascript
 `${total_alerts} new change detection alert(s) have been published on your alerts dashboard for the date of ${month_year}. The following activities have been detected in your region: ${description_alerts}. Visit your alerts dashboard here: https://explorer.${community_slug}.guardianconnector.net/alerts/alerts. If you are using CoMapeo with an archive server enabled, you can receive the alerts by synchronizing.`
 ```
+
+There are translations in English, Dutch, Portuguese, and Spanish available, with a unique content template SID for each.

--- a/f/connectors/alerts/README.md
+++ b/f/connectors/alerts/README.md
@@ -53,4 +53,4 @@ This script leverages Twilio to send a WhatsApp message to recipients with a sum
 `${total_alerts} new change detection alert(s) have been published on your alerts dashboard for the date of ${month_year}. The following activities have been detected in your region: ${description_alerts}. Visit your alerts dashboard here: https://explorer.${community_slug}.guardianconnector.net/alerts/alerts. If you are using CoMapeo with an archive server enabled, you can receive the alerts by synchronizing.`
 ```
 
-There are translations in English, Dutch, Portuguese, and Spanish available, with a unique content template SID for each.
+There are translations in English, Dutch, Portuguese, and Spanish available, with a unique content template [SID](https://www.twilio.com/docs/glossary/what-is-a-sid) for each.

--- a/f/connectors/alerts/alerts_twilio.py
+++ b/f/connectors/alerts/alerts_twilio.py
@@ -1,5 +1,5 @@
 # twilio~=9.4
-# requests==2.32.3
+# requests~=2.32.3
 
 import json
 import logging

--- a/f/connectors/alerts/alerts_twilio.py
+++ b/f/connectors/alerts/alerts_twilio.py
@@ -1,4 +1,5 @@
 # twilio~=9.4
+# requests==2.32.3
 
 import json
 import logging

--- a/f/connectors/alerts/alerts_twilio.script.lock
+++ b/f/connectors/alerts/alerts_twilio.script.lock
@@ -1,1 +1,16 @@
-twilio==9.4.1
+aiohappyeyeballs==2.4.4
+aiohttp==3.11.12
+aiohttp-retry==2.9.1
+aiosignal==1.3.2
+attrs==25.1.0
+certifi==2025.1.31
+charset-normalizer==3.4.1
+frozenlist==1.5.0
+idna==3.10
+multidict==6.1.0
+propcache==0.2.1
+pyjwt==2.10.1
+requests==2.32.3
+twilio==9.4.4
+urllib3==2.3.0
+yarl==1.18.3

--- a/f/connectors/alerts/alerts_twilio.script.yaml
+++ b/f/connectors/alerts/alerts_twilio.script.yaml
@@ -14,25 +14,27 @@ schema:
     alerts_statistics:
       type: object
       description: >-
-        An object containing alert statistics: total alerts, month/year,
-        and description of alerts.
-      default: {}
+        An object containing alert statistics: total alerts, month/year, and
+        description of alerts.
+      default: null
+      properties: {}
     community_slug:
       type: string
       description: >-
         The URL slug for the community, used to construct a link to the alerts
-        dashboard. This name is used for Twilio and must be provided for messages to
-        be sent.
+        dashboard. This name is used for Twilio and must be provided for
+        messages to be sent.
       default: null
+      originalType: string
     twilio:
       type: object
       description: >-
-        Twilio account credentials and phone numbers for sending alerts 
-        after ingesting and writing alerts to the database via a Twilio message content 
-        template.
+        Twilio account credentials and phone numbers for sending alerts  after
+        ingesting and writing alerts to the database via a Twilio message
+        content  template.
       default: null
       format: resource-c_twilio_message_template
   required:
     - alerts_statistics
-    - twilio
     - community_slug
+    - twilio

--- a/f/connectors/alerts/alerts_twilio.script.yaml
+++ b/f/connectors/alerts/alerts_twilio.script.yaml
@@ -29,9 +29,9 @@ schema:
     twilio:
       type: object
       description: >-
-        Twilio account credentials and phone numbers for sending alerts  after
+        Twilio account credentials and phone numbers for sending alerts after
         ingesting and writing alerts to the database via a Twilio message
-        content  template.
+        content template.
       default: null
       format: resource-c_twilio_message_template
   required:

--- a/f/connectors/alerts_process_post_notify.flow/flow.yaml
+++ b/f/connectors/alerts_process_post_notify.flow/flow.yaml
@@ -1,0 +1,154 @@
+summary: 'Alerts: Process, Post, and Notify'
+description: >-
+  This flow connects three scripts: (1) Alerts: Fetch alerts from Google Cloud
+  Storage (2) CoMapeo: Post Alerts (3) Alerts: Send a Twilio Message
+value:
+  modules:
+    - id: a
+      value:
+        type: script
+        input_transforms:
+          alerts_bucket:
+            type: javascript
+            expr: flow_input.alerts_bucket
+          db:
+            type: javascript
+            expr: flow_input.db
+          db_table_name:
+            type: javascript
+            expr: flow_input.db_table_name
+          destination_path:
+            type: javascript
+            expr: flow_input.destination_path
+          gcp_service_acct:
+            type: javascript
+            expr: flow_input.gcp_service_acct
+          territory_id:
+            type: javascript
+            expr: flow_input.territory_id
+        is_trigger: false
+        path: f/connectors/alerts/alerts_gcs
+    - id: b
+      value:
+        type: script
+        input_transforms:
+          comapeo:
+            type: javascript
+            expr: flow_input.comapeo
+          comapeo_project:
+            type: javascript
+            expr: flow_input.comapeo_project
+          db:
+            type: javascript
+            expr: flow_input.db
+          db_table_name:
+            type: javascript
+            expr: flow_input.db_table_name
+        is_trigger: false
+        path: f/connectors/comapeo/comapeo_alerts
+    - id: d
+      value:
+        type: script
+        input_transforms:
+          alerts_statistics:
+            type: javascript
+            expr: results.a
+          community_slug:
+            type: javascript
+            expr: flow_input.community_slug
+          twilio:
+            type: static
+            expr: flow_input.twilio
+        is_trigger: false
+        path: f/connectors/alerts/alerts_twilio
+schema:
+  $schema: 'https://json-schema.org/draft/2020-12/schema'
+  type: object
+  order:
+    - gcp_service_acct
+    - alerts_bucket
+    - territory_id
+    - db
+    - db_table_name
+    - destination_path
+    - comapeo
+    - comapeo_project
+    - community_slug
+    - twilio
+  properties:
+    alerts_bucket:
+      type: string
+      description: The name of the Google Cloud Storage bucket where the alerts are stored.
+      default: ''
+      originalType: string
+    comapeo:
+      type: object
+      description: >
+        A server URL and access token pair to connect to a CoMapeo archive
+        server.
+      format: resource-comapeo_server
+      nullable: false
+    comapeo_project:
+      type: string
+      description: A project ID on the CoMapeo server where the alerts will be posted.
+      default: ''
+      nullable: false
+    community_slug:
+      type: string
+      description: >-
+        The URL slug for the community, used to construct a link to the alerts
+        dashboard. This name is used for Twilio and must be provided for
+        messages to be sent.
+      default: ''
+      nullable: false
+    db:
+      type: object
+      description: The database connection parameters for storing tabular data.
+      default: null
+      format: resource-postgresql
+    db_table_name:
+      type: string
+      description: The name of the database table where alerts will be stored.
+      default: ''
+      originalType: string
+      pattern: '^.{1,53}$'
+    destination_path:
+      type: string
+      description: >-
+        A string specifying the local directory path where files will be
+        downloaded and processed.
+      default: /persistent-storage/datalake/change_detection/alerts
+      originalType: string
+    gcp_service_acct:
+      type: object
+      description: >-
+        Google Cloud service account credentials. This should reference the
+        contents of a `service.json` file provided by the alerts publisher. For
+        more information on setting up and retrieving GCP credentials, see:
+        https://cloud.google.com/docs/authentication/provide-credentials-adc#on-prem
+      format: resource-gcp_service_account
+    territory_id:
+      type: integer
+      description: >-
+        The territory ID (areas of interest) for which change detection alerts
+        will be retrieved. This ID is used to filter and process relevant
+        alerts.
+      format: ''
+    twilio:
+      type: object
+      description: >-
+        Twilio account credentials and phone numbers for sending alerts after
+        ingesting and writing alerts to the database via a Twilio message
+        content template.
+      format: resource-c_twilio_message_template
+      nullable: false
+  required:
+    - gcp_service_acct
+    - alerts_bucket
+    - territory_id
+    - db
+    - db_table_name
+    - comapeo
+    - comapeo_project
+    - community_slug
+    - twilio

--- a/f/flows/README.md
+++ b/f/flows/README.md
@@ -1,0 +1,5 @@
+# Flows
+
+This directory contains a collection of Windmill flows, which are step-by-step automated processes that runs tasks in order, making sure each step happens at the right time and with the right data.
+
+Windmill flows are created using the [flow editor UI](https://www.windmill.dev/docs/flows/flow_editor). Once created, you can run `wmill sync pull` to retrieve the flow code, which is composed of a YAML config file. The flow will be saved in a `«flowname».flow` directory here.

--- a/f/flows/README.md
+++ b/f/flows/README.md
@@ -1,5 +1,10 @@
 # Flows
 
-This directory contains a collection of Windmill flows, which are step-by-step automated processes that runs tasks in order, making sure each step happens at the right time and with the right data.
+This directory contains a collection of Windmill flows, which are 
+step-by-step automated processes that runs tasks in order, making sure 
+each step happens at the right time and with the right data.
 
-Windmill flows are created using the [flow editor UI](https://www.windmill.dev/docs/flows/flow_editor). Once created, you can run `wmill sync pull` to retrieve the flow code, which is composed of a YAML config file. The flow will be saved in a `«flowname».flow` directory here.
+Windmill flows are created using the [flow editor UI](https://www.windmill.dev/docs/flows/flow_editor). 
+Once created, you can run `wmill sync pull` to retrieve the flow code, 
+which is composed of a YAML config file. The flow will be saved in 
+a `«flowname».flow` directory here.

--- a/f/flows/alerts_download_post_notify.flow/README.md
+++ b/f/flows/alerts_download_post_notify.flow/README.md
@@ -1,0 +1,8 @@
+# Alerts: Download, Post, and Notify
+
+This flow connects three scripts: (1) Alerts: Fetch alerts from Google Cloud
+Storage (2) CoMapeo: Post Alerts (3) Alerts: Send a Twilio Message.
+
+The flow is designed to skip the CoMapeo and Twilio scripts if the right inputs
+are not provided. Additionally, the Twilio script will be skipped if no new
+alerts were written to the database during the Fetch alerts script.

--- a/f/flows/alerts_download_post_notify.flow/flow.yaml
+++ b/f/flows/alerts_download_post_notify.flow/flow.yaml
@@ -1,4 +1,4 @@
-summary: 'Alerts: Process, Post, and Notify'
+summary: 'Alerts: Download, Post, and Notify'
 description: >-
   This flow connects three scripts: (1) Alerts: Fetch alerts from Google Cloud
   Storage (2) CoMapeo: Post Alerts (3) Alerts: Send a Twilio Message
@@ -46,6 +46,9 @@ value:
             expr: flow_input.db_table_name
         is_trigger: false
         path: f/connectors/comapeo/comapeo_alerts
+      continue_on_error: false
+      skip_if:
+        expr: '!flow_input.comapeo || !flow_input.comapeo_project'
     - id: d
       value:
         type: script
@@ -57,10 +60,13 @@ value:
             type: javascript
             expr: flow_input.community_slug
           twilio:
-            type: static
+            type: javascript
             expr: flow_input.twilio
         is_trigger: false
         path: f/connectors/alerts/alerts_twilio
+      continue_on_error: false
+      skip_if:
+        expr: '!flow_input.twilio || !flow_input.community_slug || !results.a'
 schema:
   $schema: 'https://json-schema.org/draft/2020-12/schema'
   type: object
@@ -148,7 +154,3 @@ schema:
     - territory_id
     - db
     - db_table_name
-    - comapeo
-    - comapeo_project
-    - community_slug
-    - twilio


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-scripts-hub/issues/67.

## What I changed

* Added a flow called "Alerts: Download, Post, and Notify" to run the three alerts scripts in sequential order, using inputs provided to the flow and the results of the first script.
* CoMapeo and Twilio scripts are skipped if their respective inputs are not set. 
* Additionally, the Twilio script is skipped if the GCS script does not return anything (which happens when no new alerts were written to the database).
* The Twilio script was still missing Windmill requirements so these were added.

## Screenshots

Fully completed flow:

![image](https://github.com/user-attachments/assets/82f9ce3a-2406-4f8c-8034-80d9d26656ab)

Here, `alerts_twilio` is skipped because the result of `alerts_gcs` is undefined (as per the script logic to not return anything if no new alerts were written to the db). And, `comapeo_alerts` does not post anything as all existing alerts are returned by the CoMapeo server API:

![image](https://github.com/user-attachments/assets/be894fce-8e38-4192-bba9-6aa825eff886)

## What I'm not doing here

In the original issue, I wrote: 

> In doing so, let's optimize each script to provide the right outputs to be picked up by the next script in sequence, and handle outputs from the previous script in sequence. This will likely require some modifications to the logic of each script.

I found that this wasn't necessary, as I could configure all of the above skip logic and sequential results handling through the Flow config.