### PR TITLE
Include `confidence` field for hashing alerts_metadata UUID

### DIFF
--- a/f/connectors/alerts/alerts_gcs.py
+++ b/f/connectors/alerts/alerts_gcs.py
@@ -344,9 +344,9 @@ def prepare_alerts_metadata(alerts_metadata, territory_id):
     # Hash each row into a unique UUID; this will be used as the primary key for the metadata table
     # The hash is based on the most important columns for the metadata table, so that changes in other columns do not affect the hash
     filtered_df["metadata_uuid"] = pd.util.hash_pandas_object(
-        filtered_df[["territory_id", "month", "year", "description_alerts"]].sort_index(
-            axis=1
-        ),
+        filtered_df[
+            ["territory_id", "month", "year", "description_alerts", "confidence"]
+        ].sort_index(axis=1),
         index=False,
     )
 

--- a/f/connectors/alerts/alerts_gcs.py
+++ b/f/connectors/alerts/alerts_gcs.py
@@ -333,6 +333,21 @@ def prepare_alerts_metadata(alerts_metadata, territory_id):
     alerts_statistics : dict
         A dictionary containing alert statistics: total alerts, month/year,
         and description of alerts.
+
+    Notes
+    -----
+    The UUID for each alert metadata record is generated using a hash of the
+    following columns:
+    - territory_id: The unique identifier assigned to the territory.
+    - month: The month when the alert was detected.
+    - year: The year when the alert was detected.
+    - description_alerts: A description of the type of alert.
+    - confidence: A fixed value (either 0 or 1) indicating the confidence level
+      of the alert provider that the alert is a true positive. This value is
+      immutable once set, serving as a historical record. For instance, an alert
+      with confidence level 0 in March may have a new alert with confidence level
+      1 in April, but the March data remains unchanged to preserve a record
+      of the alert's original confidence level.
     """
     # c.f. https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
     pd.options.mode.copy_on_write = True

--- a/f/connectors/alerts/tests/alerts_gcs_test.py
+++ b/f/connectors/alerts/tests/alerts_gcs_test.py
@@ -28,7 +28,7 @@ def test_prepare_alerts_metadata():
     # Check that alerts statistics is the latest month and year in the CSV
     assert alert_statistics["month_year"] == "2/2024"
     assert alert_statistics["total_alerts"] == "1"
-    assert alert_statistics["description_alerts"] == "fake alert"
+    assert alert_statistics["description_alerts"] == "ghostly barrow noises"
 
 
 @pytest.fixture
@@ -87,9 +87,28 @@ def test_script_e2e(pg_database, mock_alerts_storage_client, tmp_path):
             assert uuid.UUID(_id)
 
             # Count of unique rows in alerts_history.csv based on UUID
-            # The last row in the CSV is a duplicate of the one before it, but updates the confidence field, hence shares the same UUID
             cursor.execute("SELECT COUNT(*) FROM fake_alerts__metadata")
-            assert cursor.fetchone()[0] == 6
+            assert cursor.fetchone()[0] == 8
+
+            # Ensure that both types of alerts are present for the month of 09/2023
+            cursor.execute(
+                "SELECT COUNT(*) FROM fake_alerts__metadata WHERE year = 2023 AND month = 9 AND description_alerts = 'ghostly_barrow_noises'"
+            )
+            assert cursor.fetchone()[0] == 1
+            cursor.execute(
+                "SELECT COUNT(*) FROM fake_alerts__metadata WHERE year = 2023 AND month = 9 AND description_alerts = 'unexpected_carrot_theft'"
+            )
+            assert cursor.fetchone()[0] == 1
+
+            # Ensure that for month of 01/2024, there are two rows with different confidence levels
+            cursor.execute(
+                "SELECT COUNT(*) FROM fake_alerts__metadata WHERE year = 2024 AND month = 1 AND confidence = 1"
+            )
+            assert cursor.fetchone()[0] == 1
+            cursor.execute(
+                "SELECT COUNT(*) FROM fake_alerts__metadata WHERE year = 2024 AND month = 1 AND confidence = 0"
+            )
+            assert cursor.fetchone()[0] == 1
 
             # Check that the confidence field is NULL if it is not defined in the CSV
             cursor.execute(

--- a/f/connectors/alerts/tests/assets/alerts_history.csv
+++ b/f/connectors/alerts/tests/assets/alerts_history.csv
@@ -1,8 +1,9 @@
 territory_id,type_alert,month,year,total_alerts,description_alerts,confidence
-100,001,09,2023,84,fake_alert,1
-100,001,10,2023,9,fake_alert,0
-100,001,11,2023,3,fake_alert,0.5
-100,001,02,2024,1,fake_alert,1
-100,001,12,2022,3,fake_alert,
-100,001,01,2024,0,fake_alert,1
-100,001,01,2024,0,fake_alert,0
+100,001,09,2023,84,ghostly_barrow_noises,1
+100,002,09,2023,50,unexpected_carrot_theft,1
+100,001,10,2023,9,ghostly_barrow_noises,0
+100,001,11,2023,3,ghostly_barrow_noises,0.5
+100,001,02,2024,1,ghostly_barrow_noises,1
+100,001,12,2022,3,ghostly_barrow_noises,
+100,001,01,2024,0,ghostly_barrow_noises,1
+100,001,01,2024,0,ghostly_barrow_noises,0


### PR DESCRIPTION
When working on https://github.com/ConservationMetrics/gc-scripts-hub/pull/82, I overlooked that the alerts provider can return multiple rows per month and year when `confidence` values vary (not just when `description_alerts` differs, which is what that PR sought to resolve).

For example:

```
territory_id | type_alert | month | year | total_alerts | description_alerts | confidence
100 | 1 | 10 | 2024 | 5 | bunnies | 1
100 | 1 | 10 | 2024 | 1 | bunnies | 0
100 | 1 | 11 | 2024 | 3 | bunnies | 1
100 | 1 | 11 | 2024 | 2 | bunnies | 0
```

This PR fixes that by including `confidence` towards the hashing of UUIDs, which will guarantee that each of these rows will be written as a unique record. 

I've also adapted the tests to check the `alerts_metadat` table for unique rows with the same month+year but different values for `description_alerts` and `confidence`.

**NOTE:** Much like for #82 I will need to re-generate `alerts_metadata` tables for each user after merging, as this will result in different / new UUIDs. (Hitherto, the scripts would update rows with the same month & year but different confidence values in a random order, which is how I discovered this oversight.)