### PR TITLE
Fix: build an array from `g__coordinates` 

### DIFF
--- a/f/export/postgres_to_geojson/postgres_to_geojson.py
+++ b/f/export/postgres_to_geojson/postgres_to_geojson.py
@@ -86,8 +86,13 @@ def format_data_as_geojson(data):
         for col, value in zip(columns, row):
             if col == "_id":
                 feature_id = value
-            elif col.startswith("g__"):
-                geometry[col[3:]] = value
+            elif col == "g__coordinates":
+                if value:
+                    geometry["coordinates"] = json.loads(value)
+                else:
+                    geometry["coordinates"] = None
+            elif col == "g__type":
+                geometry["type"] = value
             else:
                 properties[col] = value
 

--- a/f/export/postgres_to_geojson/tests/postgres_to_geojson_test.py
+++ b/f/export/postgres_to_geojson/tests/postgres_to_geojson_test.py
@@ -1,5 +1,6 @@
-from f.export.postgres_to_geojson.postgres_to_geojson import main
 import json
+
+from f.export.postgres_to_geojson.postgres_to_geojson import main
 
 
 def test_script_e2e(pg_database, database_mock_data, tmp_path):
@@ -22,5 +23,5 @@ def test_script_e2e(pg_database, database_mock_data, tmp_path):
             assert "properties" in feature
 
         assert data["features"][0]["id"] == "doc_id_1"
-        assert data["features"][0]["geometry"]["coordinates"] == "[151.2093, -33.8688]"
+        assert data["features"][0]["geometry"]["coordinates"] == [151.2093, -33.8688]
         assert data["features"][0]["properties"]["project_name"] == "Forest Expedition"


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-scripts-hub/issues/84.

The script was setting `geometry.coordinates` as a string e.g. `"[lon, lat]"`.

Now we are constructing an array to comply by valid GeoJSON schema.

EDIT: FYI that sometimes Mapeo data (and maybe other sources?) have features with a null value for coordinates. So this script accounts for that edge case. I can add a comment if desired. (The GeoJSON export will still be valid and work in softwares like QGIS).