### PR TITLE
Add shell script to push changes to multiple workspaces at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,31 @@ Some of the tools available in the Guardian Connector Scripts Hub are:
 ![Available scripts, flows, and apps in gc-scripts-hub](gc-scripts-hub.jpg)
 _A Windmill Workspace populated with some of the tools in this repository._
 
-## Deploying the code to a Windmill workspace
+## Deploying the code to Windmill workspaces
 
 [Install the Windmill CLI](https://www.windmill.dev/docs/advanced/cli), and
 [set it up to talk to your deployed Workspace](https://www.windmill.dev/docs/advanced/cli/workspace-management).
 
-Then push the code in this Git repo your workspace:
+Then push the code in this Git repo to your workspace:
 
     wmill sync push --skip-variables
 
 Folders named `./tests/` are excluded by `wmill.yml` from syncing to Windmill —
 because otherwise Windmill tries to make the tests (as with ALL python files) into bona-fide Windmill scripts.
+
+This repo also provides a shell script to batch push changes to a number of workspaces at once. To use this:
+
+1. Ensure the script is executable:
+
+       chmod +x bin/push.sh
+
+2. Populate a list of workspace names in a `.env` file, like so:
+
+       WORKSPACES=gc-windmill,gc-testing-server,...
+
+3. Run:
+
+       bin/push.sh
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -32,19 +32,13 @@ Then push the code in this Git repo to your workspace:
 Folders named `./tests/` are excluded by `wmill.yml` from syncing to Windmill —
 because otherwise Windmill tries to make the tests (as with ALL python files) into bona-fide Windmill scripts.
 
-This repo also provides a shell script to batch push changes to a number of workspaces at once. To use this:
+This repo also provides a shell script to batch push changes to a number of workspaces at once. To use this, set the `WORKSPACES` environment variable with a list of workspace names. You can do this directly in the command line:
 
-1. Ensure the script is executable:
+       WORKSPACES=gc-windmill,gc-testing-server bin/push.sh
 
-       chmod +x bin/push.sh
+   Alternatively, use a subshell to load a WORKSPACES variable from a `.env` file without affecting your current shell environment:
 
-2. Populate a list of workspace names in a `.env` file, like so:
-
-       WORKSPACES=gc-windmill,gc-testing-server,...
-
-3. Run:
-
-       bin/push.sh
+       (set -a; source .env; set +a; bin/push.sh)
 
 ## Development
 

--- a/bin/push.sh
+++ b/bin/push.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+source .env
+
+IFS=',' read -ra WORKSPACE_LIST <<< "$WORKSPACES"
+
+for workspace in "${WORKSPACE_LIST[@]}"; do
+  wmill workspace switch "$workspace"
+  wmill sync push --skip-variables <<< "Y"
+done

--- a/bin/push.sh
+++ b/bin/push.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
-
 set -e
 
-source .env
+if [ -z "$WORKSPACES" ]; then
+  echo "Error: No workspaces defined in WORKSPACES environment variable."
+  exit 1
+fi
 
 IFS=',' read -ra WORKSPACE_LIST <<< "$WORKSPACES"
 


### PR DESCRIPTION
## Goal

To provide a simple shell script (and documentation) to push changes to multiple workspaces, defined in a `.env` file.