### PR TITLE
Implement common logic for saving to disk & writing to db for `arcgis_feature_layer` and `comapeo_observations`

### DIFF
--- a/f/common_logic/save_disk.py
+++ b/f/common_logic/save_disk.py
@@ -21,7 +21,7 @@ def get_safe_file_path(storage_path: str, db_table_name: str, file_type: str):
     return file_path
 
 
-def save_export_file(
+def save_data_to_file(
     data, db_table_name: str, storage_path: str, file_type: str = "json"
 ):
     """

--- a/f/common_logic/save_disk.py
+++ b/f/common_logic/save_disk.py
@@ -21,9 +21,7 @@ def get_safe_file_path(storage_path: str, db_table_name: str, file_type: str):
     return file_path
 
 
-def save_data_to_file(
-    data, db_table_name: str, storage_path: str, file_type: str = "json"
-):
+def save_data_to_file(data, filename: str, storage_path: str, file_type: str = "json"):
     """
     Saves the provided data to a file in the specified format and storage path.
 
@@ -31,8 +29,8 @@ def save_data_to_file(
     ----------
     data : list or dict
         The data to be saved. For CSV, should be a list of rows including a header.
-    db_table_name : str
-        The name of the database table, used to name the output file.
+    filename : str
+        The name of the file to save the data to, without extension.
     storage_path : str
         The directory path where the file will be saved.
     file_type : str
@@ -40,7 +38,7 @@ def save_data_to_file(
     """
     storage_path = Path(storage_path)
     storage_path.mkdir(parents=True, exist_ok=True)
-    file_path = get_safe_file_path(storage_path, db_table_name, file_type)
+    file_path = get_safe_file_path(storage_path, filename, file_type)
 
     if file_type in {"geojson", "json"}:
         with file_path.open("w") as f:

--- a/f/connectors/arcgis/arcgis_feature_layer.py
+++ b/f/connectors/arcgis/arcgis_feature_layer.py
@@ -50,13 +50,13 @@ def main(
         file_type="geojson",
     )
 
-    geojson_path = Path(storage_path) / f"{db_table_name}.geojson"
+    rel_geojson_path = Path(db_table_name) / f"{db_table_name}.geojson"
 
     save_geojson_to_postgres(
         db,
         db_table_name,
-        geojson_path,
-        storage_path,
+        rel_geojson_path,
+        attachment_root,
         False,  # do not delete the file after saving to Postgres
     )
 

--- a/f/connectors/comapeo/comapeo_observations.py
+++ b/f/connectors/comapeo/comapeo_observations.py
@@ -302,7 +302,9 @@ def download_and_transform_comapeo_data(
             # Other geometry types and formats may be added in the future
             feature = {
                 "type": "Feature",
-                "id": observation.pop("docId"),
+                # docId is the unique identifier for the observation. We'll use it as the ID for the feature
+                # and also include it in the properties
+                "id": observation["docId"],
                 "properties": {
                     k: str(v) for k, v in observation.items() if k not in ["lat", "lon"]
                 },

--- a/f/connectors/geojson/geojson_to_postgres.py
+++ b/f/connectors/geojson/geojson_to_postgres.py
@@ -217,7 +217,9 @@ class GeoJSONDbWriter:
         cursor = conn.cursor()
 
         # Safely truncate the table to 63 characters
+        # TODO: ...while retaining uniqueness
         table_name = table_name[:63]
+
         existing_fields = self._inspect_schema(table_name)
         rows = []
         for entry in outputs:

--- a/f/connectors/geojson/geojson_to_postgres.py
+++ b/f/connectors/geojson/geojson_to_postgres.py
@@ -216,6 +216,8 @@ class GeoJSONDbWriter:
         conn = self._get_conn()
         cursor = conn.cursor()
 
+        # Safely truncate the table to 63 characters
+        table_name = table_name[:63]
         existing_fields = self._inspect_schema(table_name)
         rows = []
         for entry in outputs:
@@ -229,7 +231,9 @@ class GeoJSONDbWriter:
         if missing_field_keys:
             self._create_missing_fields(table_name, missing_field_keys)
 
-        logger.info(f"Attempting to write {len(rows)} submissions to the DB.")
+        logger.info(
+            f"Attempting to write {len(rows)} submissions to the DB to table {table_name}"
+        )
 
         inserted_count = 0
         updated_count = 0

--- a/f/connectors/globalforestwatch/gfw_alerts.py
+++ b/f/connectors/globalforestwatch/gfw_alerts.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import requests
 
 from f.common_logic.db_operations import postgresql
-from f.common_logic.save_disk import save_export_file
+from f.common_logic.save_disk import save_data_to_file
 from f.connectors.geojson.geojson_to_postgres import main as save_geojson_to_postgres
 
 # type names that refer to Windmill Resources
@@ -37,7 +37,7 @@ def main(
 
     alerts_geojson = format_alerts_as_geojson(alerts, type_of_alert)
 
-    save_export_file(
+    save_data_to_file(
         alerts_geojson,
         db_table_name,
         storage_path,

--- a/f/export/postgres_to_file/postgres_to_csv.py
+++ b/f/export/postgres_to_file/postgres_to_csv.py
@@ -1,7 +1,7 @@
 import logging
 
 from f.common_logic.db_operations import conninfo, fetch_data_from_postgres, postgresql
-from f.common_logic.save_disk import save_export_file
+from f.common_logic.save_disk import save_data_to_file
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -17,4 +17,4 @@ def main(
     # Convert rows to lists to ensure compatibility with CSV writer, which requires iterable rows
     data = [columns, *map(list, rows)]
 
-    save_export_file(data, db_table_name, storage_path, file_type="csv")
+    save_data_to_file(data, db_table_name, storage_path, file_type="csv")

--- a/f/export/postgres_to_file/postgres_to_geojson.py
+++ b/f/export/postgres_to_file/postgres_to_geojson.py
@@ -2,7 +2,7 @@ import json
 import logging
 
 from f.common_logic.db_operations import conninfo, fetch_data_from_postgres, postgresql
-from f.common_logic.save_disk import save_export_file
+from f.common_logic.save_disk import save_data_to_file
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -17,7 +17,7 @@ def main(
 
     feature_collection = format_data_as_geojson(data)
 
-    save_export_file(
+    save_data_to_file(
         feature_collection, db_table_name, storage_path, file_type="geojson"
     )
 


### PR DESCRIPTION
## Goal

Towards https://github.com/ConservationMetrics/gc-scripts-hub/issues/86.

## Screenshots

![image](https://github.com/user-attachments/assets/df1da618-92b7-4a83-aba1-af8ea239d074)
_For CoMapeo, a GeoJSON file is now saved in the same location as attachments_

## What I changed

* Rename `save_export_file` to `save_data_to_file` to clarify that it is a generic function that can be used at any time to save data to disk, not only when exporting.
* The ArcGIS Feature Layer script now uses this `save_data_to_file` function instead of providing its own bespoke logic to do so.
* The CoMapeo Observations script now implements both `save_data_to_file` and `save_geojson_to_postgres`. 
  * `download_and_transform_comapeo_data` now transforms the incoming CoMapeo Archive Server data into a GeoJSON Feature Collection.
  * `CoMapeoDBWriter` class was removed entirely. Any business logic e.g. about converting `docId` was moved to `download_and_transform_comapeo_data`. Also, one line of code about  truncating table names was moved to the GeoJSON-to-Potgres script (as it is good practice for any usage of this script).

## What I'm not doing here

* Adapting the Locus Map script, which will be a decent chunk of work (due to working with 3 different file formats) so will be a separate PR.
