### PR TITLE
[comapeo] Pre-scan attachments dir to avoid redundant downloads

### DIFF
--- a/f/connectors/comapeo/comapeo_observations.py
+++ b/f/connectors/comapeo/comapeo_observations.py
@@ -118,7 +118,7 @@ def fetch_comapeo_projects(server_url, access_token, comapeo_project_blocklist):
     return comapeo_projects
 
 
-def build_existing_file_map(directory):
+def build_existing_file_set(directory):
     """
     Builds a set of existing file names (without extensions) in the specified directory.
     This is used to check for existing files before downloading new ones.
@@ -299,7 +299,7 @@ def download_and_transform_comapeo_data(
         attachment_dir = (
             Path(attachment_root) / "comapeo" / sanitized_project_name / "attachments"
         )
-        existing_file_stems = build_existing_file_map(attachment_dir)
+        existing_file_stems = build_existing_file_set(attachment_dir)
 
         for i, observation in enumerate(current_project_data):
             observation["project_name"] = project_name

--- a/f/connectors/comapeo/comapeo_observations.py
+++ b/f/connectors/comapeo/comapeo_observations.py
@@ -6,6 +6,7 @@ import json
 import logging
 import mimetypes
 import re
+from os import listdir
 from pathlib import Path
 from typing import TypedDict
 
@@ -117,7 +118,16 @@ def fetch_comapeo_projects(server_url, access_token, comapeo_project_blocklist):
     return comapeo_projects
 
 
-def download_attachment(url, headers, save_path):
+def build_existing_file_map(directory):
+    """
+    Builds a set of existing file names (without extensions) in the specified directory.
+    This is used to check for existing files before downloading new ones.
+    """
+    files = listdir(directory) if Path(directory).exists() else []
+    return {Path(f).stem for f in files}  # just base names, no extensions
+
+
+def download_attachment(url, headers, save_path, existing_file_stems):
     """
     Downloads a file from a specified URL and saves it to a given path.
 
@@ -129,6 +139,8 @@ def download_attachment(url, headers, save_path):
         A dictionary of HTTP headers to send with the request, such as authentication tokens.
     save_path : str
         The file system path where the downloaded file will be saved.
+    existing_file_stems : set
+        A set of existing file names (without extensions) to check against before downloading.
 
     Returns
     -------
@@ -150,10 +162,16 @@ def download_attachment(url, headers, save_path):
 
     """
     skipped_attachments = 0
-    if Path(save_path).exists():
-        logger.debug("File already exists, skipping download.")
+    base_name = Path(save_path).name
+
+    if base_name in existing_file_stems:
+        logger.debug(f"{base_name} already exists, skipping download.")
         skipped_attachments += 1
-        return Path(save_path).name, skipped_attachments
+        # Try to find matching full filename (with extension)
+        full_path = next(
+            (f for f in Path(save_path).parent.glob(f"{base_name}.*")), None
+        )
+        return (full_path.name if full_path else base_name), skipped_attachments
 
     try:
         response = requests.get(url, headers=headers)
@@ -162,8 +180,7 @@ def download_attachment(url, headers, save_path):
         content_type = response.headers.get("Content-Type", "")
         extension = mimetypes.guess_extension(content_type) or ""
 
-        file_name = Path(url).name + extension
-
+        file_name = base_name + extension
         save_path = Path(str(save_path) + extension)
 
         save_path.parent.mkdir(parents=True, exist_ok=True)
@@ -253,6 +270,7 @@ def download_and_transform_comapeo_data(
 
     comapeo_data = {}
     attachment_failed = False
+
     for index, project in enumerate(comapeo_projects):
         project_id = project["project_id"]
         project_name = project["project_name"]
@@ -277,6 +295,11 @@ def download_and_transform_comapeo_data(
             raise ValueError("Invalid JSON response received from server.")
 
         skipped_attachments = 0
+
+        attachment_dir = (
+            Path(attachment_root) / "comapeo" / sanitized_project_name / "attachments"
+        )
+        existing_file_stems = build_existing_file_map(attachment_dir)
 
         for i, observation in enumerate(current_project_data):
             observation["project_name"] = project_name
@@ -306,17 +329,11 @@ def download_and_transform_comapeo_data(
                 filenames = []
                 for attachment in observation["attachments"]:
                     if "url" in attachment:
-                        logger.info(attachment["url"])
                         file_name, skipped = download_attachment(
                             attachment["url"],
                             headers,
-                            str(
-                                Path(attachment_root)
-                                / "comapeo"
-                                / sanitized_project_name
-                                / "attachments"
-                                / Path(attachment["url"]).name
-                            ),
+                            str(attachment_dir / Path(attachment["url"]).name),
+                            existing_file_stems,
                         )
                         skipped_attachments += skipped
                         if file_name is not None:


### PR DESCRIPTION
## Goal

Previously, the CoMapeo observations script checked for file existence **before** knowing the MIME type (and thus the final file extension), which caused every attachment to be re-downloaded even if it already existed locally. This fix resolves that by checking against existing stems before making any requests.

This change assumes that the CoMapeo API will never return two of the same stem but with different extensions (e.g. `my-observation.m4a` and `my-observation.jpg`).

## What I changed

* Added `build_existing_file_map()` to scan the CoMapeo project's `attachments/` directory and track all existing files by stem.
* Modified `download_attachment()` to skip download if a file with the same stem already exists (regardless of extension).
* Updated `download_and_transform_comapeo_data()` to use the new file-stem map when checking for already-downloaded attachments
