### PR TITLE
[KoboToolbox] Store form metadata, and compose label lookup table

### DIFF
--- a/f/common_logic/db_operations.py
+++ b/f/common_logic/db_operations.py
@@ -67,6 +67,10 @@ class StructuredDBWriter:
         PostgreSQL connection string.
     table_name : str
         Destination table name for the data.
+    suffix : bool
+        If provided, appends `__<suffix>` to the table name. The full name will be truncated
+        to 63 characters to satisfy PostgreSQL’s identifier length limit. This is useful for
+        creating auxiliary tables (e.g., labels, columns) associated with a primary data table.
     use_mapping_table : bool
       If True, maintains a mapping table that maps original keys to SQL-safe column names.
     sanitize_keys : bool
@@ -90,6 +94,7 @@ class StructuredDBWriter:
         self,
         db_connection_string,
         table_name,
+        suffix=None,
         use_mapping_table=False,
         sanitize_keys=False,
         reverse_properties_separated_by=None,
@@ -98,8 +103,16 @@ class StructuredDBWriter:
     ):
         self.db_connection_string = db_connection_string
         # Safely truncate the table to 63 characters
+        # If suffix is provided (e.g., "labels"), create a derived table name.
         # TODO: ...while retaining uniqueness
-        self.table_name = table_name[:63]
+        self.base_table_name = table_name
+        self.suffix = suffix
+
+        if suffix:
+            combined = f"{table_name}__{suffix}"
+            self.table_name = combined[:63]
+        else:
+            self.table_name = table_name[:63]
         self.use_mapping_table = use_mapping_table
         self.sanitize_keys = sanitize_keys
         self.reverse_separator = reverse_properties_separated_by

--- a/f/common_logic/db_operations.py
+++ b/f/common_logic/db_operations.py
@@ -109,8 +109,9 @@ class StructuredDBWriter:
         self.suffix = suffix
 
         if suffix:
-            combined = f"{table_name}__{suffix}"
-            self.table_name = combined[:63]
+            max_base_length = 63 - len(f"__{suffix}")
+            base = table_name[:max_base_length]
+            self.table_name = f"{base}__{suffix}"
         else:
             self.table_name = table_name[:63]
         self.use_mapping_table = use_mapping_table

--- a/f/common_logic/tests/db_operations_test.py
+++ b/f/common_logic/tests/db_operations_test.py
@@ -93,3 +93,26 @@ def test_long_table_name_truncation(mock_db_connection):
     # Verify both tables exist and are accessible
     assert writer._inspect_schema(writer.table_name)
     assert writer._inspect_schema(mapping_table)
+
+
+def test_truncated_table_name_retains_suffix(mock_db_connection):
+    very_long_name = (
+        "this_is_an_extremely_long_table_name_that_should_truncate_properly"
+    )
+    suffix = "labels"
+    writer = StructuredDBWriter(
+        mock_db_connection,
+        very_long_name,
+        suffix=suffix,
+        sanitize_keys=True,
+        use_mapping_table=False,
+    )
+
+    # Table name should end with __labels and be max 63 chars
+    assert writer.table_name.endswith(f"__{suffix}")
+    assert len(writer.table_name) <= 63
+
+    # Actual table should be creatable and inspectable
+    submissions = [{"_id": "1", "field": "value"}]
+    writer.handle_output(submissions)
+    assert writer._inspect_schema(writer.table_name)

--- a/f/connectors/kobotoolbox/README.md
+++ b/f/connectors/kobotoolbox/README.md
@@ -1,6 +1,6 @@
 # KoboToolbox: Fetch Survey Responses
 
-This script fetches form metadata and survey submissions from the KoboToolbox REST API.  Field translations are extracted from metadata and written to a PostgreSQL `labels` lookup table. The structured part of survey submissions are written to a PostgreSQL table, while media attachments are downloaded to disk in a specified directory.
+This script fetches form metadata and survey submissions from the KoboToolbox REST API.  Field translations are extracted from metadata and written to a PostgreSQL `labels` lookup table. The structured part of survey submissions are written to a PostgreSQL table, while media attachments are downloaded to disk in a specified directory. Form metadata is also saved to disk as a JSON file.
 
 ## Label Lookup Table (`__labels`)
 

--- a/f/connectors/kobotoolbox/README.md
+++ b/f/connectors/kobotoolbox/README.md
@@ -1,5 +1,5 @@
 # KoboToolbox: Fetch Survey Responses
 
-This script fetches form submissions from the KoboToolbox REST API, transforms the data for SQL compatibility, and stores it in a PostgreSQL database. Additionally, it downloads any attachments and saves them to a specified directory.
+This script fetches form submissions from the KoboToolbox REST API, transforms the data for SQL compatibility, and stores it in a PostgreSQL database. It also stores form metadata and downloads any attachments and saves them to a specified directory.  
 
 For information on the KoboToolbox API, see [KoboToolbox API Documentation](https://support.kobotoolbox.org/api.html).

--- a/f/connectors/kobotoolbox/README.md
+++ b/f/connectors/kobotoolbox/README.md
@@ -2,8 +2,23 @@
 
 This script fetches survey submissions from the KoboToolbox REST API, transforms them for SQL compatibility, and writes the results to a PostgreSQL database. It also downloads any media attachments and saves the form metadata to disk.
 
-In addition to storing raw submissions and metadata, the script builds a `<table_name>__labels` lookup table of form labels for multilingual support. If the form includes `translations` (as specified in the translations field of the metadata), the script extracts them into columns named `label_<code>`, where `<code>` corresponds to the language code, with one row per question or choice.
+## Label Lookup Table (`__labels`)
 
-If no translations are provided (e.g., `translations: [null]`), a single `label` column is extracted instead with the default label.
+The script creates a secondary table named `<table_name>__labels` to store question and choice labels from the form definition. If the form metadata includes translations (via the `translations` field), the table will include one column per language (e.g. `label_en`, `label_es`, etc.). If no translations are provided (e.g., `translations: [null]`), only the default label is included as a single `label` column.
 
-For information on the KoboToolbox API, see [KoboToolbox API Documentation](https://support.kobotoolbox.org/api.html).
+Each row represents one form element (from either the `survey` or `choices` section), with the following structure:
+
+
+| Column             | Description                                                           |
+|--------------------|-----------------------------------------------------------------------|
+| `type`             | Either `"survey"` or `"choices"` indicating the form section          |
+| `name`             | The name of the form element (question or choice)                     |
+| `label_<lang>`     | The label text in each language (e.g. `label_en`, `label_es`, etc.)   |
+| `label`            | The default label (only present if no translations are defined)       |
+| `_id`              | Deterministic hash based on the row content (used as a unique key)    |
+
+This table can be used for rendering field translations on downstream front ends or clients.
+
+## 📚 Reference
+
+* KoboToolbox API Documentation: https://support.kobotoolbox.org/api.html

--- a/f/connectors/kobotoolbox/README.md
+++ b/f/connectors/kobotoolbox/README.md
@@ -1,5 +1,9 @@
 # KoboToolbox: Fetch Survey Responses
 
-This script fetches form submissions from the KoboToolbox REST API, transforms the data for SQL compatibility, and stores it in a PostgreSQL database. It also stores form metadata and downloads any attachments and saves them to a specified directory.  
+This script fetches survey submissions from the KoboToolbox REST API, transforms them for SQL compatibility, and writes the results to a PostgreSQL database. It also downloads any media attachments and saves the form metadata to disk.
+
+In addition to storing raw submissions, the script builds a lookup table of form labels for multilingual support. If the form includes `translations` (as specified in the translations field of the metadata), the script extracts them into a separate table named `<table_name>__translations`, with one row per question or choice.
+
+If no translations are provided (e.g., `translations: [null]`), a single label `column` is extracted instead with the default label.
 
 For information on the KoboToolbox API, see [KoboToolbox API Documentation](https://support.kobotoolbox.org/api.html).

--- a/f/connectors/kobotoolbox/README.md
+++ b/f/connectors/kobotoolbox/README.md
@@ -2,8 +2,8 @@
 
 This script fetches survey submissions from the KoboToolbox REST API, transforms them for SQL compatibility, and writes the results to a PostgreSQL database. It also downloads any media attachments and saves the form metadata to disk.
 
-In addition to storing raw submissions, the script builds a lookup table of form labels for multilingual support. If the form includes `translations` (as specified in the translations field of the metadata), the script extracts them into a separate table named `<table_name>__translations`, with one row per question or choice.
+In addition to storing raw submissions and metadata, the script builds a `<table_name>__labels` lookup table of form labels for multilingual support. If the form includes `translations` (as specified in the translations field of the metadata), the script extracts them into columns named `label_<code>`, where `<code>` corresponds to the language code, with one row per question or choice.
 
-If no translations are provided (e.g., `translations: [null]`), a single label `column` is extracted instead with the default label.
+If no translations are provided (e.g., `translations: [null]`), a single `label` column is extracted instead with the default label.
 
 For information on the KoboToolbox API, see [KoboToolbox API Documentation](https://support.kobotoolbox.org/api.html).

--- a/f/connectors/kobotoolbox/README.md
+++ b/f/connectors/kobotoolbox/README.md
@@ -1,23 +1,22 @@
 # KoboToolbox: Fetch Survey Responses
 
-This script fetches survey submissions from the KoboToolbox REST API, transforms them for SQL compatibility, and writes the results to a PostgreSQL database. It also downloads any media attachments and saves the form metadata to disk.
+This script fetches form metadata and survey submissions from the KoboToolbox REST API.  Field translations are extracted from metadata and written to a PostgreSQL `labels` lookup table. The structured part of survey submissions are written to a PostgreSQL table, while media attachments are downloaded to disk in a specified directory.
 
 ## Label Lookup Table (`__labels`)
 
-The script creates a secondary table named `<table_name>__labels` to store question and choice labels from the form definition. If the form metadata includes translations (via the `translations` field), the table will include one column per language (e.g. `label_en`, `label_es`, etc.). If no translations are provided (e.g., `translations: [null]`), only the default label is included as a single `label` column.
+The script creates a secondary table named `<table_name>__labels` to store question and choice labels from the form definition. If the form metadata includes translations (via the `translations` field), each translation is stored as a separate row—one per language—for each form element.
 
-Each row represents one form element (from either the `survey` or `choices` section), with the following structure:
+Each row represents one label for a form element (from either the `survey` or `choices` section), with the following structure: 
 
+| Column     | Type    | Description                                                                 |
+|------------|---------|-----------------------------------------------------------------------------|
+| `type`     | TEXT    | Either `"survey"` or `"choices"` indicating the form section               |
+| `name`     | TEXT    | The name of the form element (question or choice)                          |
+| `language` | TEXT    | The language of the label (e.g., `"en"`, `"es"`, `"pt"`)                    |
+| `label`    | TEXT    | The label text in the specified language                                   |
+| `_id`      | TEXT    | Deterministic hash based on the row content (used as a unique key)         |
 
-| Column             | Description                                                           |
-|--------------------|-----------------------------------------------------------------------|
-| `type`             | Either `"survey"` or `"choices"` indicating the form section          |
-| `name`             | The name of the form element (question or choice)                     |
-| `label_<lang>`     | The label text in each language (e.g. `label_en`, `label_es`, etc.)   |
-| `label`            | The default label (only present if no translations are defined)       |
-| `_id`              | Deterministic hash based on the row content (used as a unique key)    |
-
-This table can be used for rendering field translations on downstream front ends or clients.
+This table can be used for rendering field translations in downstream clients, selecting the appropriate label by language, or falling back gracefully when a translation is missing.
 
 ## 📚 Reference
 

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -74,6 +74,14 @@ def download_form_metadata(
     """
     Downloads form metadata from the KoboToolbox server and saves it to a JSON file.
 
+    The metadata is saved to disk intentionally (not as a temporary artifact),
+    as it may have value for future processes beyond immediate label extraction.
+    The saved file includes additional metadata information about the form such as sector,
+    country, field properties, and more.
+
+    This file does **not** contain sensitive secrets. The only identifiers it includes are the
+    KoboToolbox username (typically public-facing) and the form ID.
+
     Parameters
     ----------
     server_base_url : str

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -58,6 +58,7 @@ def main(
         f"KoboToolbox responses successfully written to database table: [{db_table_name}]"
     )
 
+    # If form_labels is empty, there were no translatable labels found in metadata
     if form_labels:
         kobo_translations_writer = StructuredDBWriter(
             conninfo(db), f"{db_table_name}__labels"
@@ -124,6 +125,8 @@ def extract_form_labels(form_metadata):
     """
     Extracts and prepares normalized labels for form questions and choices from the provided form metadata.
     This function is designed to create a lookup table for form translations.
+
+    If no labels are found in the metadata, returns an empty list.
 
     Parameters
     ----------

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -61,7 +61,7 @@ def main(
     # If form_labels is empty, there were no translatable labels found in metadata
     if form_labels:
         kobo_translations_writer = StructuredDBWriter(
-            conninfo(db), f"{db_table_name}__labels"
+            conninfo(db), db_table_name, suffix="labels"
         )
         kobo_translations_writer.handle_output(form_labels)
         logger.info(

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -2,6 +2,8 @@
 # psycopg2-binary
 # requests~=2.32
 
+import hashlib
+import json
 import logging
 from pathlib import Path
 
@@ -27,23 +29,80 @@ def main(
     kobo_server_base_url = kobotoolbox["server_url"]
     kobo_api_key = kobotoolbox["api_key"]
 
-    form_data = download_form_responses_and_attachments(
+    form_data, form_translations = download_form_data_and_attachments(
         kobo_server_base_url, kobo_api_key, form_id, db_table_name, attachment_root
     )
 
     transformed_form_data = format_geometry_fields(form_data)
 
-    db_writer = StructuredDBWriter(
+    kobo_response_writer = StructuredDBWriter(
         conninfo(db),
         db_table_name,
         use_mapping_table=True,
         sanitize_keys=True,
         reverse_properties_separated_by="/",
     )
-    db_writer.handle_output(transformed_form_data)
+    kobo_response_writer.handle_output(transformed_form_data)
     logger.info(
         f"KoboToolbox responses successfully written to database table: [{db_table_name}]"
     )
+
+    if form_translations:
+        kobo_translations_writer = StructuredDBWriter(
+            conninfo(db), f"{db_table_name}__translations"
+        )
+        kobo_translations_writer.handle_output(form_translations)
+        logger.info(
+            f"KoboToolbox translations successfully written to database table: [{db_table_name}__translations]"
+        )
+
+
+def _extract_form_translations(form_metadata):
+    """
+    Extracts translated labels for form questions and choices. The purpose is to
+    prepare a lookup table for form translations.
+
+    Parameters
+    ----------
+    form_metadata : dict
+
+    Returns
+    -------
+    list of dict
+        Each dict has keys: '_id', 'type', 'name', and 'translation_<lang_code>'.
+    """
+    content = form_metadata.get("content", {})
+    translations = content.get("translations", [])
+
+    if not translations:
+        return []
+
+    lang_codes = [
+        lang[lang.find("(") + 1 : lang.find(")")]
+        for lang in translations
+        if "(" in lang and ")" in lang
+    ]
+
+    rows = []
+
+    for section in ["survey", "choices"]:
+        for item in content.get(section, []):
+            row = {
+                "type": section,
+                "name": item["name"],
+            }
+            labels = item.get("label", [])
+            for i, code in enumerate(lang_codes):
+                if i < len(labels):
+                    row[f"translation_{code}"] = labels[i]
+
+            # Deterministic _id based on row content
+            hash_input = json.dumps(row, sort_keys=True).encode("utf-8")
+            row["_id"] = hashlib.md5(hash_input).hexdigest()
+
+            rows.append(row)
+
+    return rows
 
 
 def _download_submission_attachments(
@@ -97,10 +156,14 @@ def _download_submission_attachments(
     return skipped_attachments
 
 
-def download_form_responses_and_attachments(
+def download_form_data_and_attachments(
     server_base_url, kobo_api_key, form_id, db_table_name, attachment_root
 ):
-    """Download form responses and their attachments from the KoboToolbox API.
+    """Fetch and store form metadata, responses, and attachments from the KoboToolbox API.
+
+    This function retrieves form metadata, including translations, and saves it to a specified directory.
+    It then downloads form responses and their associated attachments, storing them in the specified
+    directory structure. If attachments already exist, they are skipped.
 
     Parameters
     ----------
@@ -112,47 +175,58 @@ def download_form_responses_and_attachments(
         The unique identifier of the form to download.
     db_table_name : str
         The name of the database table where the form responses will be stored.
-     attachment_root : str
+    attachment_root : str
         The root directory where attachments will be saved.
 
     Returns
     -------
-    list
-        A list of form submissions data.
+    tuple
+        A tuple containing a list of form submissions data and a list of form translations.
     """
     headers = {
         "Authorization": f"Token {kobo_api_key}",
         "Accept": "application/json, text/javascript, */*; q=0.01",
     }
-    # First let's download the form metadata
+    # First let's download the form metadata. The form metadata contains the form
+    # name and the data URI that we need to download the form responses.
+    # We also want to save the form metadata itself and compile the translations
+    # for the form.
     form_uri = f"{server_base_url}/api/v2/assets/{form_id}/"
-    response = requests.get(form_uri, headers=headers)
-    response.raise_for_status()
+    form_metadata_response = requests.get(form_uri, headers=headers)
+    form_metadata_response.raise_for_status()
 
     # Save the form metadata to a JSON file on the datalake
     save_path = Path(attachment_root) / db_table_name
     save_data_to_file(
-        response.json(),
+        form_metadata_response.json(),
         f"{db_table_name}_metadata",
         save_path,
         "json",
     )
 
-    data_uri = response.json()["data"]
-    form_name = response.json().get("name")
+    # Extract the data URI, form name, and translations from the metadata
+    data_uri = form_metadata_response.json()["data"]
+    form_name = form_metadata_response.json().get("name")
+    languages = form_metadata_response.json().get("content", {}).get("translations", [])
+    form_languages = ",".join(filter(None, languages)) if languages != [None] else None
 
-    # Next download the form questions & metadata
+    form_metadata = form_metadata_response.json()
+    form_translations = _extract_form_translations(form_metadata)
+
+    # Next download the form responses.
     # FIXME: need to paginate. Maximum results per page is 30000.
-    response = requests.get(data_uri, headers=headers)
-    response.raise_for_status()
+    form_data_response = requests.get(data_uri, headers=headers)
+    form_data_response.raise_for_status()
 
-    form_submissions = response.json()["results"]
+    form_submissions = form_data_response.json()["results"]
 
     skipped_attachments = 0
 
     for submission in form_submissions:
         submission["dataset_name"] = form_name
         submission["data_source"] = "KoboToolbox"
+        if form_languages:
+            submission["form_translations"] = form_languages
 
         # Download attachments for each submission, if they exist
         if "_attachments" in submission:
@@ -164,7 +238,7 @@ def download_form_responses_and_attachments(
         logger.info(f"Skipped downloading {skipped_attachments} media attachment(s).")
 
     logger.info(f"[Form {form_id}] Downloaded {len(form_submissions)} submission(s).")
-    return form_submissions
+    return form_submissions, form_translations
 
 
 def format_geometry_fields(form_data):

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -137,7 +137,7 @@ def extract_form_labels(form_metadata):
     translations = content.get("translations", [])
 
     if not translations or translations == [None]:
-        # No multilingual translations, so just write plain 'label'
+        # No multilingual translations are provided in the form, so just write plain 'label'
         rows = []
         for section in ["survey", "choices"]:
             for item in content.get(section, []):
@@ -151,7 +151,10 @@ def extract_form_labels(form_metadata):
                 rows.append(row)
         return rows
 
-    # Real translations exist
+    # Extract the language codes from the translations
+    # Example: "English (en)", "Spanish (es)", etc.
+    # We assume that the language code is always in parentheses
+    # and is the last part of the string.
     lang_codes = [
         lang[lang.find("(") + 1 : lang.find(")")]
         for lang in translations

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.script.yaml
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.script.yaml
@@ -1,5 +1,5 @@
 summary: 'KoboToolbox: Fetch Survey Responses'
-description: Uses KoboToolbox REST API to download all form submissions
+description: Uses KoboToolbox REST API to download form submissions, attachments, and metadata
 lock: '!inline f/connectors/kobotoolbox/kobotoolbox_responses.script.lock'
 concurrency_time_window_s: 0
 kind: script

--- a/f/connectors/kobotoolbox/tests/assets/server_responses.py
+++ b/f/connectors/kobotoolbox/tests/assets/server_responses.py
@@ -5,7 +5,91 @@ def kobo_form(uri, form_id, form_name):
     return {
         "name": form_name,
         "uid": form_id,
+        "owner__username": "kobo_admin",
         "data": posixpath.join(uri, "api/v2/assets", form_id, "data/"),
+        "content": {
+            "schema": "1",
+            "survey": [
+                {
+                    "name": "Record_your_current_location",
+                    "type": "geopoint",
+                    "label": [
+                        "Record your current location",
+                        "Registre la ubicación actual",
+                        "Registre a localização atual",
+                    ],
+                    "$qpath": "Record_your_current_location",
+                    "$xpath": "Record_your_current_location",
+                    "$autoname": "Record_your_current_location",
+                },
+                {
+                    "name": "Estimate_height_of_your_tree_in_meters",
+                    "type": "integer",
+                    "label": [
+                        "Estimate the height of your tree (in meters)",
+                        "Estime la altura de su árbol (en metros)",
+                        "Estime a altura da sua árvore (em metros)",
+                    ],
+                    "$qpath": "Estimate_height_of_your_tree_in_meters",
+                    "$xpath": "Estimate_height_of_your_tree_in_meters",
+                    "$autoname": "Estimate_height_of_your_tree_in_meters",
+                },
+                {
+                    "name": "I_like_this_tree_because",
+                    "type": "select_multiple",
+                    "label": [
+                        "Why do you like this tree?",
+                        "¿Por qué te gusta este árbol?",
+                        "Por que você gosta desta árvore?",
+                    ],
+                    "select_from_list_name": "tree_reasons",
+                    "$qpath": "I_like_this_tree_because",
+                    "$xpath": "I_like_this_tree_because",
+                    "$autoname": "I_like_this_tree_because",
+                },
+                {
+                    "name": "Take_a_photo_of_this_tree",
+                    "type": "image",
+                    "label": [
+                        "Take a photo of this tree",
+                        "Toma una foto de este árbol",
+                        "Tire uma foto desta árvore",
+                    ],
+                    "$qpath": "Take_a_photo_of_this_tree",
+                    "$xpath": "Take_a_photo_of_this_tree",
+                    "$autoname": "Take_a_photo_of_this_tree",
+                },
+            ],
+            "choices": [
+                {
+                    "list_name": "tree_reasons",
+                    "name": "shade",
+                    "label": ["Shade", "Sombra", "Sombra"],
+                },
+                {
+                    "list_name": "tree_reasons",
+                    "name": "food",
+                    "label": ["Food", "Comida", "Comida"],
+                },
+                {
+                    "list_name": "tree_reasons",
+                    "name": "wildlife_habitat",
+                    "label": [
+                        "Wildlife Habitat",
+                        "Hábitat de vida silvestre",
+                        "Habitat da vida selvagem",
+                    ],
+                },
+                {
+                    "list_name": "tree_reasons",
+                    "name": "beauty",
+                    "label": ["Beauty", "Belleza", "Beleza"],
+                },
+            ],
+            "settings": {"version": "1", "default_language": "English (en)"},
+            "translated": ["label"],
+            "translations": ["English (en)", "Spanish (es)", "Portuguese (pt)"],
+        },
     }
 
 

--- a/f/connectors/kobotoolbox/tests/conftest.py
+++ b/f/connectors/kobotoolbox/tests/conftest.py
@@ -58,7 +58,7 @@ def koboserver(mocked_responses):
 @pytest.fixture
 def koboserver_no_translations(mocked_responses):
     metadata = server_responses.kobo_form(server_url, form_id, form_name)
-    metadata["content"].pop("translations", None)
+    metadata["content"]["translations"] = [None]
 
     _register_common_mocks(mocked_responses, form_id, metadata)
 

--- a/f/connectors/kobotoolbox/tests/conftest.py
+++ b/f/connectors/kobotoolbox/tests/conftest.py
@@ -7,50 +7,66 @@ import testing.postgresql
 
 from f.connectors.kobotoolbox.tests.assets import server_responses
 
+server_url = "http://kobotoolbox.example.org"
+form_id = "mimsyweretheborogoves"
+form_name = "Arboles"
+
 
 @pytest.fixture
 def mocked_responses():
-    """responses.RequestsMock context, for testing code that makes HTTP requests."""
     with responses.RequestsMock() as rsps:
         yield rsps
 
 
-@pytest.fixture
-def koboserver(mocked_responses):
-    """A mock Kobo Server that you can use to provide survey responses"""
-
-    @dataclass
-    class KoboServer:
-        account: dict
-        form_id: str
-
-    server_url = "http://kobotoolbox.example.org"
-    form_id = "mimsyweretheborogoves"
-    form_name = "Arboles"
-
-    mocked_responses.get(
+def _register_common_mocks(rsps, form_id, metadata):
+    rsps.get(
         f"{server_url}/api/v2/assets/{form_id}/",
-        json=server_responses.kobo_form(server_url, form_id, form_name),
+        json=metadata,
         status=200,
     )
-    mocked_responses.get(
+    rsps.get(
         f"{server_url}/api/v2/assets/{form_id}/data/",
         json=server_responses.kobo_form_submissions(server_url, form_id),
         status=200,
     )
-    mocked_responses.get(
+    rsps.get(
         re.compile(rf"{server_url}/api/v2/assets/{form_id}/data/\d+/attachments/\d+/?"),
         body=open("f/connectors/kobotoolbox/tests/assets/trees.png", "rb").read(),
         content_type="image/png",
         headers={"Content-Length": "3632"},
     )
 
+
+def _build_koboserver_fixture(metadata):
+    @dataclass
+    class KoboServer:
+        account: dict
+        form_id: str
+
     return KoboServer(dict(server_url=server_url, api_key="Callooh!Callay!"), form_id)
 
 
 @pytest.fixture
+def koboserver(mocked_responses):
+    metadata = server_responses.kobo_form(server_url, form_id, form_name)
+
+    _register_common_mocks(mocked_responses, form_id, metadata)
+
+    return _build_koboserver_fixture(metadata)
+
+
+@pytest.fixture
+def koboserver_no_translations(mocked_responses):
+    metadata = server_responses.kobo_form(server_url, form_id, form_name)
+    metadata["content"].pop("translations", None)
+
+    _register_common_mocks(mocked_responses, form_id, metadata)
+
+    return _build_koboserver_fixture(metadata)
+
+
+@pytest.fixture
 def pg_database():
-    """A dsn that may be used to connect to a live (local for test) postgresql server"""
     db = testing.postgresql.Postgresql(port=7654)
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")

--- a/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
+++ b/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
@@ -50,3 +50,53 @@ def test_script_e2e(koboserver, pg_database, tmp_path):
                 "SELECT COUNT(*) FROM kobo_responses__columns WHERE original_column = 'meta/instanceID' AND sql_column = 'instanceID__meta'"
             )
             assert cursor.fetchone()[0] == 1
+
+    # Form translations are written to a SQL Table
+    with psycopg2.connect(**pg_database) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT COUNT(*) FROM kobo_responses__translations")
+            assert cursor.fetchone()[0] == 8
+
+            # Verify specific translations for survey items
+            cursor.execute(
+                "SELECT translation_en, translation_es, translation_pt FROM kobo_responses__translations WHERE name = 'Record_your_current_location'"
+            )
+            assert cursor.fetchone() == (
+                "Record your current location",
+                "Registre la ubicación actual",
+                "Registre a localização atual",
+            )
+
+            cursor.execute(
+                "SELECT translation_en, translation_es, translation_pt FROM kobo_responses__translations WHERE name = 'Estimate_height_of_your_tree_in_meters'"
+            )
+            assert cursor.fetchone() == (
+                "Estimate the height of your tree (in meters)",
+                "Estime la altura de su árbol (en metros)",
+                "Estime a altura da sua árvore (em metros)",
+            )
+
+            # Verify specific translations for choice items
+            cursor.execute(
+                "SELECT translation_en, translation_es, translation_pt FROM kobo_responses__translations WHERE name = 'shade'"
+            )
+            assert cursor.fetchone() == ("Shade", "Sombra", "Sombra")
+
+            cursor.execute(
+                "SELECT translation_en, translation_es, translation_pt FROM kobo_responses__translations WHERE name = 'wildlife_habitat'"
+            )
+            assert cursor.fetchone() == (
+                "Wildlife Habitat",
+                "Hábitat de vida silvestre",
+                "Habitat da vida selvagem",
+            )
+
+            # Check that the type is set for survey / choice items
+            cursor.execute(
+                "SELECT type FROM kobo_responses__translations WHERE name = 'Record_your_current_location'"
+            )
+            assert cursor.fetchone() == ("survey",)
+            cursor.execute(
+                "SELECT type FROM kobo_responses__translations WHERE name = 'shade'"
+            )
+            assert cursor.fetchone() == ("choices",)

--- a/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
+++ b/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
@@ -18,6 +18,14 @@ def test_script_e2e(koboserver, pg_database, tmp_path):
     # Attachments are saved to disk
     assert (asset_storage / table_name / "attachments" / "1637241249813.jpg").exists()
 
+    # Metadata is saved to disk
+    assert (asset_storage / table_name / f"{table_name}_metadata.json").exists()
+    with open(asset_storage / table_name / f"{table_name}_metadata.json") as f:
+        metadata = f.read()
+    assert all(
+        key in metadata for key in ["name", "uid", "owner__username", "data", "content"]
+    )
+
     # Survey responses are written to a SQL Table
     with psycopg2.connect(**pg_database) as conn:
         with conn.cursor() as cursor:

--- a/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
+++ b/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
@@ -54,52 +54,78 @@ def test_script_e2e(koboserver, pg_database, tmp_path):
     # Form labels are written to a SQL Table
     with psycopg2.connect(**pg_database) as conn:
         with conn.cursor() as cursor:
+            # (4 survey + 4 choices) × 3 languages = 24 rows
             cursor.execute(f"SELECT COUNT(*) FROM {table_name}__labels")
-            assert cursor.fetchone()[0] == 8
+            assert cursor.fetchone()[0] == 24
 
             # Verify specific translations for survey items
             cursor.execute(
-                f"SELECT label_en, label_es, label_pt FROM {table_name}__labels WHERE name = 'Record_your_current_location'"
+                f"""
+                SELECT label FROM {table_name}__labels 
+                WHERE name = 'Record_your_current_location' AND language = 'en'
+                """
             )
-            assert cursor.fetchone() == (
-                "Record your current location",
-                "Registre la ubicación actual",
-                "Registre a localização atual",
-            )
+            assert cursor.fetchone()[0] == "Record your current location"
 
             cursor.execute(
-                f"SELECT label_en, label_es, label_pt FROM {table_name}__labels WHERE name = 'Estimate_height_of_your_tree_in_meters'"
+                f"""
+                SELECT label FROM {table_name}__labels 
+                WHERE name = 'Record_your_current_location' AND language = 'es'
+                """
             )
-            assert cursor.fetchone() == (
-                "Estimate the height of your tree (in meters)",
-                "Estime la altura de su árbol (en metros)",
-                "Estime a altura da sua árvore (em metros)",
+            assert cursor.fetchone()[0] == "Registre la ubicación actual"
+
+            cursor.execute(
+                f"""
+                SELECT label FROM {table_name}__labels 
+                WHERE name = 'Record_your_current_location' AND language = 'pt'
+                """
+            )
+            assert cursor.fetchone()[0] == "Registre a localização atual"
+
+            cursor.execute(
+                f"""
+                SELECT label FROM {table_name}__labels 
+                WHERE name = 'Estimate_height_of_your_tree_in_meters' AND language = 'en'
+                """
+            )
+            assert (
+                cursor.fetchone()[0] == "Estimate the height of your tree (in meters)"
             )
 
             # Verify specific translations for choice items
             cursor.execute(
-                f"SELECT label_en, label_es, label_pt FROM {table_name}__labels WHERE name = 'shade'"
+                f"""
+                SELECT label FROM {table_name}__labels 
+                WHERE name = 'shade' AND language = 'es'
+                """
             )
-            assert cursor.fetchone() == ("Shade", "Sombra", "Sombra")
+            assert cursor.fetchone()[0] == "Sombra"
 
             cursor.execute(
-                f"SELECT label_en, label_es, label_pt FROM {table_name}__labels WHERE name = 'wildlife_habitat'"
+                f"""
+                SELECT label FROM {table_name}__labels 
+                WHERE name = 'wildlife_habitat' AND language = 'pt'
+                """
             )
-            assert cursor.fetchone() == (
-                "Wildlife Habitat",
-                "Hábitat de vida silvestre",
-                "Habitat da vida selvagem",
-            )
+            assert cursor.fetchone()[0] == "Habitat da vida selvagem"
 
             # Check that the type is set for survey / choice items
             cursor.execute(
-                f"SELECT type FROM {table_name}__labels WHERE name = 'Record_your_current_location'"
+                f"""
+                SELECT DISTINCT type FROM {table_name}__labels 
+                WHERE name = 'Record_your_current_location'
+                """
             )
-            assert cursor.fetchone() == ("survey",)
+            assert cursor.fetchone()[0] == "survey"
+
             cursor.execute(
-                f"SELECT type FROM {table_name}__labels WHERE name = 'shade'"
+                f"""
+                SELECT DISTINCT type FROM {table_name}__labels 
+                WHERE name = 'shade'
+                """
             )
-            assert cursor.fetchone() == ("choices",)
+            assert cursor.fetchone()[0] == "choices"
 
 
 def test_script_e2e__no_translations(koboserver_no_translations, pg_database, tmp_path):


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-scripts-hub/issues/29. 

Unlike what was originally discussed in that issue (storing _all_ metadata in a flattened database), this implementation stores the full metadata to disk for future reference and extracts only the labels—since that's the only part likely to be useful for downstream clients.

~~This PR is stacked on top of [`common-db-writer`](https://github.com/ConservationMetrics/gc-scripts-hub/pull/93) (not yet merged).~~

## Screenshots

![image](https://github.com/user-attachments/assets/b4aa79ee-c899-4ee3-98f1-8fa36492b4fd)
_Modified script at runtime with our demo form, and new label lookup table_

## What I changed

* Refactored `download_form_responses_and_attachments()` into several smaller functions:
  * `download_form_metadata()` — fetches metadata, saves it to disk, and returns the content;
  * `extract_form_labels()` — prepares a lookup table for labels from the form metadata;
  * `download_form_responses_and_attachments()` — now focused solely on retrieving form submissions and attachments. Minor addition: each submission now includes a `form_translations` field (if applicable), so downstream code can resolve translated labels.
* Expanded test server responses and assertions to verify that a `__labels` table is created with the expected content in two cases: when `translations` are present, and when they are not.

## What I'm not doing here

Making it optional to create a `__label` lookup table via a Windmill param. Why not? I feel that having this table will always have value for working with Kobo data in any front end. I've spent enough time in Superset trying to come up with clever SQL rewrites of machine-readable field names, when I could have just used the original human-readable strings from the Kobo form...