### PR TITLE
Always sanitize keys for SQL compatibility

### DIFF
--- a/f/common_logic/db_operations.py
+++ b/f/common_logic/db_operations.py
@@ -58,32 +58,30 @@ def fetch_data_from_postgres(db_connection_string: str, table_name: str):
 
 class StructuredDBWriter:
     """
-    StructuredDBWriter writes structured or semi-structured data (e.g., form submissions, GeoJSON features)
-    into a PostgreSQL table. It optionally supports dynamic schema evolution, key sanitization, and column mapping, or can rely on a predefined schema setup.
+     StructuredDBWriter writes structured or semi-structured data (e.g., form submissions, GeoJSON features)
+     into a PostgreSQL table. It optionally supports dynamic schema evolution and column mapping, or can rely on a predefined schema setup.
 
-    Parameters
-    ----------
-    db_connection_string : str
-        PostgreSQL connection string.
-    table_name : str
-        Destination table name for the data.
-    use_mapping_table : bool
-      If True, maintains a mapping table that maps original keys to SQL-safe column names.
-    sanitize_keys : bool
-      If True, applies transformations to make keys SQL-compatible, including optional string replacements.
+     Parameters
+     ----------
+     db_connection_string : str
+         PostgreSQL connection string.
+     table_name : str
+         Destination table name for the data.
+     use_mapping_table : bool
+       If True, maintains a mapping table that maps original keys to SQL-safe column names.
     reverse_properties_separated_by : str or None
-      If provided, splits keys on this character, reverses segments, and rejoins — useful for nested property flattening.
-    str_replace : list of tuple, optional
-        List of (old, new) strings to apply to keys during sanitization.
-    predefined_schema : callable or None, optional
-        If provided, this function is executed to create or validate the schema before inserting any data.
-        Signature: `(cursor, table_name) -> None`
+       If provided, splits keys on this character, reverses segments, and rejoins — useful for nested property flattening.
+     str_replace : list of tuple, optional
+         List of (old, new) strings to apply to keys during sanitization.
+     predefined_schema : callable or None, optional
+         If provided, this function is executed to create or validate the schema before inserting any data.
+         Signature: `(cursor, table_name) -> None`
 
-    Typical Use Cases
-    -----------------
-    - Writing cleaned KoboToolbox or ODK form data to a SQL table.
-    - Ingesting GeoJSON features with flattened geometry and properties.
-    - Storing alert data with a strict, predefined schema.
+     Typical Use Cases
+     -----------------
+     - Writing cleaned KoboToolbox or ODK form data to a SQL table.
+     - Ingesting GeoJSON features with flattened geometry and properties.
+     - Storing alert data with a strict, predefined schema.
     """
 
     def __init__(
@@ -91,7 +89,6 @@ class StructuredDBWriter:
         db_connection_string,
         table_name,
         use_mapping_table=False,
-        sanitize_keys=False,
         reverse_properties_separated_by=None,
         str_replace=[("/", "__")],
         predefined_schema=None,
@@ -101,7 +98,6 @@ class StructuredDBWriter:
         # TODO: ...while retaining uniqueness
         self.table_name = table_name[:63]
         self.use_mapping_table = use_mapping_table
-        self.sanitize_keys = sanitize_keys
         self.reverse_separator = reverse_properties_separated_by
         self.str_replace = str_replace
         self.predefined_schema = predefined_schema
@@ -304,17 +300,14 @@ class StructuredDBWriter:
         original_to_sql = {}
 
         for submission in submissions:
-            if self.sanitize_keys:
-                sanitized, updated = sanitize(
-                    submission,
-                    existing_mappings,
-                    reverse_properties_separated_by=self.reverse_separator,
-                    str_replace=self.str_replace,
-                )
-                rows.append((sanitized, existing_mappings))
-                original_to_sql.update(updated)
-            else:
-                rows.append((submission, {}))
+            sanitized, updated = sanitize(
+                submission,
+                existing_mappings,
+                reverse_properties_separated_by=self.reverse_separator,
+                str_replace=self.str_replace,
+            )
+            rows.append((sanitized, existing_mappings))
+            original_to_sql.update(updated)
 
         missing_map_keys = set()
         missing_field_keys = set()

--- a/f/common_logic/tests/db_operations_test.py
+++ b/f/common_logic/tests/db_operations_test.py
@@ -106,7 +106,6 @@ def test_truncated_table_name_retains_suffix(mock_db_connection):
         mock_db_connection,
         very_long_name,
         suffix=suffix,
-        sanitize_keys=True,
         use_mapping_table=False,
     )
 

--- a/f/common_logic/tests/db_operations_test.py
+++ b/f/common_logic/tests/db_operations_test.py
@@ -14,28 +14,9 @@ def mock_db_connection():
     db.stop()
 
 
-@pytest.mark.skip("Bug: #98")
-def test_mapping_table_creation_no_sanitize(mock_db_connection):
+def test_mapping_table_creation(mock_db_connection):
     writer = StructuredDBWriter(
-        mock_db_connection, "test_forms", sanitize_keys=False, use_mapping_table=True
-    )
-
-    submissions = [
-        {"_id": "1", "complex.field": "value1"},
-        {"_id": "2", "complex.field": "value2"},
-    ]
-    writer.handle_output(submissions)
-
-    # Check the mapping table contains expected mappings
-    mapping_table = f"{writer.table_name}__columns"
-    mappings = writer._get_existing_mappings(mapping_table)
-    assert "complex.field" in mappings
-    assert mappings["complex.field"] == "complex.field"
-
-
-def test_mapping_table_creation_and_sanitize(mock_db_connection):
-    writer = StructuredDBWriter(
-        mock_db_connection, "test_forms", sanitize_keys=True, use_mapping_table=True
+        mock_db_connection, "test_forms", use_mapping_table=True
     )
 
     submissions = [
@@ -55,7 +36,6 @@ def test_reverse_properties_handling(mock_db_connection):
     writer = StructuredDBWriter(
         mock_db_connection,
         "nested_data",
-        sanitize_keys=True,
         reverse_properties_separated_by="/",
         str_replace=[("/", "__")],
     )
@@ -74,7 +54,7 @@ def test_reverse_properties_handling(mock_db_connection):
 def test_long_table_name_truncation(mock_db_connection):
     very_long_name = "this_is_an_extremely_long_table_name_that_exceeds_postgresql_limits_significantly_2023"
     writer = StructuredDBWriter(
-        mock_db_connection, very_long_name, sanitize_keys=True, use_mapping_table=True
+        mock_db_connection, very_long_name, use_mapping_table=True
     )
 
     # Verify both main and mapping table names are properly truncated

--- a/f/connectors/geojson/geojson_to_postgres.py
+++ b/f/connectors/geojson/geojson_to_postgres.py
@@ -25,7 +25,6 @@ def main(
         conninfo(db),
         db_table_name,
         use_mapping_table=False,
-        sanitize_keys=True,
         reverse_properties_separated_by=None,
     )
     db_writer.handle_output(transformed_geojson_data)

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -36,7 +36,6 @@ def main(
         conninfo(db),
         db_table_name,
         use_mapping_table=True,
-        sanitize_keys=True,
         reverse_properties_separated_by="/",
     )
     db_writer.handle_output(transformed_form_data)

--- a/f/connectors/odk/odk_responses.py
+++ b/f/connectors/odk/odk_responses.py
@@ -73,7 +73,6 @@ def main(
             conninfo(db),
             db_table_name,
             use_mapping_table=True,
-            sanitize_keys=True,
             reverse_properties_separated_by="/",
         )
         db_writer.handle_output(transformed_form_data)


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-scripts-hub/issues/98.

I opted to always sanitize keys to address the issue described there. I don’t see a compelling reason _not_ to. In practice, we had only set `sanitize_keys=True` in connector scripts where this is likely to come up (ODK, Kobo), but it really should be a core operation of the `StructuredDBWriter` class to prevent potential SQL incompatibility.

I did keep `use_mapping_table` as optional. I think a column mapping table will be redundant for data sources where keys are already SQL-compliant or only require minor rewrites, like anything in a GeoJSON-compliant format.

Note: Kobo and ODK tests already check for a `__columns` mapping table, and the GeoJSON tests check to ensure it does not exist. 