### PR TITLE
Support fetching VIIRS fire alerts data from GFW

### DIFF
--- a/f/connectors/globalforestwatch/README.md
+++ b/f/connectors/globalforestwatch/README.md
@@ -7,6 +7,7 @@ Currently, we support fetching the following alerts from GFW:
 * [Integrated deforestation alerts](https://data.globalforestwatch.org/datasets/gfw::integrated-deforestation-alerts/about)
 * [GLAD alerts](https://glad.umd.edu/dataset/glad-forest-alerts) - either Landsat or Sentinel-2
 * [RADD alerts](https://data.globalforestwatch.org/datasets/gfw::deforestation-alerts-radd/about)
+* [NASA VIIRS fire alerts](https://data.globalforestwatch.org/documents/gfw::viirs-active-fires/about)
 
 > [!NOTE]
 > This script makes a query request to conduct on-the-fly data analysis. This means that for large areas, it may take a while for the GFW API to return the result. Additionally, there is a **maximum allowed payload size of 6291556 bytes**.

--- a/f/connectors/globalforestwatch/gfw_alerts.py
+++ b/f/connectors/globalforestwatch/gfw_alerts.py
@@ -136,7 +136,10 @@ def format_alerts_as_geojson(alerts: list, type_of_alert: str):
         # Again, VIIRS fire alerts have a different schema than the other alerts.
         if type_of_alert == "nasa_viirs_fire_alerts":
             date = alert["alert__date"]
-            confidence = alert["confidence__cat"]
+            confidence_map = {"n": "nominal", "l": "low", "h": "high"}
+            confidence = confidence_map.get(
+                alert["confidence__cat"], alert["confidence__cat"]
+            )
         else:
             date = alert[f"{type_of_alert}__date"]
             confidence = alert[f"{type_of_alert}__confidence"]

--- a/f/connectors/globalforestwatch/gfw_alerts.py
+++ b/f/connectors/globalforestwatch/gfw_alerts.py
@@ -94,7 +94,13 @@ def fetch_alerts_from_gfw(
         # The advantage would be that the geometry can be more complex than a simple bounding box.
         # Let's decide whether to do this or not after this script gets some usage.
         "geometry": {"type": "Polygon", "coordinates": bbox_array},
-        "sql": f"SELECT latitude, longitude, {type_of_alert}__date, {type_of_alert}__confidence FROM results WHERE {type_of_alert}__date >= '{minimum_date}'",
+        # Note that VIIRS fire alerts have a different schema than the other alerts.
+        "sql": (
+            f"SELECT latitude, longitude, "
+            f"{'alert__date, confidence__cat' if type_of_alert == 'nasa_viirs_fire_alerts' else f'{type_of_alert}__date, {type_of_alert}__confidence'} "
+            f"FROM results WHERE "
+            f"{'alert__date' if type_of_alert == 'nasa_viirs_fire_alerts' else f'{type_of_alert}__date'} >= '{minimum_date}'"
+        ),
     }
 
     response = requests.post(url, headers=headers, json=data)
@@ -127,13 +133,18 @@ def format_alerts_as_geojson(alerts: list, type_of_alert: str):
     for alert in alerts:
         lat = alert["latitude"]
         lon = alert["longitude"]
-        date = alert["gfw_integrated_alerts__date"]
-        confidence = alert["gfw_integrated_alerts__confidence"]
+        # Again, VIIRS fire alerts have a different schema than the other alerts.
+        if type_of_alert == "nasa_viirs_fire_alerts":
+            date = alert["alert__date"]
+            confidence = alert["confidence__cat"]
+        else:
+            date = alert[f"{type_of_alert}__date"]
+            confidence = alert[f"{type_of_alert}__confidence"]
         # GFW alerts do not have IDs. So, let's create a unique id by combining date, latitude, and longitude, and removing non-integer characters.
         id = re.sub(
             r"\D",
             "",
-            f"{alert['gfw_integrated_alerts__date']}{alert['latitude']}{alert['longitude']}",
+            f"{date}{lat}{lon}",
         )
 
         feature = {
@@ -141,7 +152,7 @@ def format_alerts_as_geojson(alerts: list, type_of_alert: str):
             "id": id,
             "geometry": {
                 "type": "Point",
-                "coordinates": [lon, lat],
+                "coordinates": [float(lon), float(lat)],
             },
             # TODO: Converge on a minimal set of common standards for alerts properties from this script and `alerts_gcs`
             # TODO: Ensure that the front end (GuardianConnector Explorer) can work with this format

--- a/f/connectors/globalforestwatch/gfw_alerts.script.yaml
+++ b/f/connectors/globalforestwatch/gfw_alerts.script.yaml
@@ -20,11 +20,13 @@ schema:
       description: >-
         The type of alert to fetch from the Global Forest Watch API. This can
         be one of the following:  `gfw_integrated_alerts` (recommended), 
-        `gfw_radd_alerts`, `umd_glad_landsat_alerts`, or `umd_glad_sentinel2_alerts.
+        `nasa_viirs_fire_alerts`, `gfw_radd_alerts`, `umd_glad_landsat_alerts`, 
+        or `umd_glad_sentinel2_alerts.
       default: "gfw_integrated_alerts"
       enum:
         - gfw_integrated_alerts
         - gfw_radd_alerts
+        - nasa_viirs_fire_alerts
         - umd_glad_landsat_alerts
         - umd_glad_sentinel2_alerts
       originalType: string  

--- a/f/connectors/globalforestwatch/tests/assets/server_responses.py
+++ b/f/connectors/globalforestwatch/tests/assets/server_responses.py
@@ -51,3 +51,28 @@ def gfw_integrated_alerts():
             },
         ]
     }
+
+
+def gfw_viirs_fire_alerts():
+    return {
+        "data": [
+            {
+                "latitude": 5.70545,
+                "longitude": -55.22595,
+                "alert__date": "2024-10-31",
+                "confidence__cat": "h",
+            },
+            {
+                "latitude": 5.70545,
+                "longitude": -55.22585,
+                "alert__date": "2024-10-31",
+                "confidence__cat": "l",
+            },
+            {
+                "latitude": 5.70535,
+                "longitude": -55.22595,
+                "alert__date": "2024-10-31",
+                "confidence__cat": "h",
+            },
+        ]
+    }

--- a/f/connectors/globalforestwatch/tests/conftest.py
+++ b/f/connectors/globalforestwatch/tests/conftest.py
@@ -26,6 +26,11 @@ def gfw_server(mocked_responses):
         json=server_responses.gfw_integrated_alerts(),
         status=200,
     )
+    mocked_responses.post(
+        "https://data-api.globalforestwatch.org/dataset/nasa_viirs_fire_alerts/latest/query",
+        json=server_responses.gfw_viirs_fire_alerts(),
+        status=200,
+    )
 
     gfw_api = dict(api_key="my-api-key")
 

--- a/f/connectors/globalforestwatch/tests/gfw_alerts_test.py
+++ b/f/connectors/globalforestwatch/tests/gfw_alerts_test.py
@@ -35,3 +35,31 @@ def test_script_e2e(gfw_server, pg_database, tmp_path):
 
             cursor.execute("SELECT confidence FROM gfw_alerts LIMIT 1 OFFSET 1")
             assert cursor.fetchone()[0] == "medium"
+
+    main(
+        gfw_server.gfw_api,
+        "[[[-73.9731, 40.7644], [-73.9819, 40.7681], [-73.9580, 40.8003], [-73.9493, 40.7967], [-73.9731, 40.7644]]]",
+        "nasa_viirs_fire_alerts",
+        "2025-01-01",
+        pg_database,
+        "gfw_viirs_alerts",
+        asset_storage,
+    )
+
+    # GeoJSON file is saved to disk
+    assert (asset_storage / "gfw_viirs_alerts" / "gfw_viirs_alerts.geojson").exists()
+
+    with psycopg2.connect(**pg_database) as conn:
+        # Survey responses from gfw_viirs_alerts are written to a SQL Table in expected format
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT COUNT(*) FROM gfw_viirs_alerts")
+            assert cursor.fetchone()[0] == 3
+
+            cursor.execute("SELECT g__type FROM gfw_viirs_alerts LIMIT 1")
+            assert cursor.fetchone()[0] == "Point"
+
+            cursor.execute("SELECT g__coordinates FROM gfw_viirs_alerts LIMIT 1")
+            assert cursor.fetchone()[0] == "[-55.22595, 5.70545]"
+
+            cursor.execute("SELECT confidence FROM gfw_viirs_alerts LIMIT 1 OFFSET 1")
+            assert cursor.fetchone()[0] == "low"


### PR DESCRIPTION
## Goal

To expand the GFW connector script by allowing the user to download VIIRS data. In addition to adding the dataset parameter option, the VIIRS data schema is somewhat different from the other supported datasets, so some small changes were made to the API query and `format_alerts_as_geojson` function.