### PR TITLE
Improve data schema for alert detection in the GFW script

### DIFF
--- a/f/connectors/globalforestwatch/gfw_alerts.py
+++ b/f/connectors/globalforestwatch/gfw_alerts.py
@@ -157,13 +157,14 @@ def format_alerts_as_geojson(alerts: list, type_of_alert: str):
                 "type": "Point",
                 "coordinates": [float(lon), float(lat)],
             },
-            # TODO: Converge on a minimal set of common standards for alerts properties from this script and `alerts_gcs`
-            # TODO: Ensure that the front end (GuardianConnector Explorer) can work with this format
             "properties": {
                 "alert_id": id,
                 "alert_type": type_of_alert,
                 "confidence": confidence,
-                "date": date,
+                "date_start_t0": date,
+                "date_end_t0": date,
+                "date_start_t1": date,
+                "date_end_t1": date,
                 "data_source": "Global Forest Watch",
             },
         }

--- a/f/connectors/globalforestwatch/gfw_alerts.py
+++ b/f/connectors/globalforestwatch/gfw_alerts.py
@@ -165,6 +165,8 @@ def format_alerts_as_geojson(alerts: list, type_of_alert: str):
                 "date_end_t0": date,
                 "date_start_t1": date,
                 "date_end_t1": date,
+                "year_detec": date.split("-")[0],
+                "month_detec": date.split("-")[1],
                 "data_source": "Global Forest Watch",
             },  # Note: GFW alerts do not have date start and end. So, we set them to the same value.
         }

--- a/f/connectors/globalforestwatch/gfw_alerts.py
+++ b/f/connectors/globalforestwatch/gfw_alerts.py
@@ -166,7 +166,7 @@ def format_alerts_as_geojson(alerts: list, type_of_alert: str):
                 "date_start_t1": date,
                 "date_end_t1": date,
                 "data_source": "Global Forest Watch",
-            },
+            },  # Note: GFW alerts do not have date start and end. So, we set them to the same value.
         }
         features.append(feature)
 

--- a/f/connectors/globalforestwatch/tests/gfw_alerts_test.py
+++ b/f/connectors/globalforestwatch/tests/gfw_alerts_test.py
@@ -71,3 +71,14 @@ def test_script_e2e(gfw_server, pg_database, tmp_path):
 
             cursor.execute("SELECT date_end_t0 FROM gfw_viirs_alerts LIMIT 1 OFFSET 1")
             assert cursor.fetchone()[0] == "2024-10-31"
+
+            cursor.execute(
+                "SELECT date_start_t1 FROM gfw_viirs_alerts LIMIT 1 OFFSET 1"
+            )
+            assert cursor.fetchone()[0] == "2024-10-31"
+
+            cursor.execute("SELECT year_detec FROM gfw_viirs_alerts LIMIT 1 OFFSET 1")
+            assert cursor.fetchone()[0] == "2024"
+
+            cursor.execute("SELECT month_detec FROM gfw_viirs_alerts LIMIT 1 OFFSET 1")
+            assert cursor.fetchone()[0] == "10"

--- a/f/connectors/globalforestwatch/tests/gfw_alerts_test.py
+++ b/f/connectors/globalforestwatch/tests/gfw_alerts_test.py
@@ -63,3 +63,11 @@ def test_script_e2e(gfw_server, pg_database, tmp_path):
 
             cursor.execute("SELECT confidence FROM gfw_viirs_alerts LIMIT 1 OFFSET 1")
             assert cursor.fetchone()[0] == "low"
+
+            cursor.execute(
+                "SELECT date_start_t0 FROM gfw_viirs_alerts LIMIT 1 OFFSET 1"
+            )
+            assert cursor.fetchone()[0] == "2024-10-31"
+
+            cursor.execute("SELECT date_end_t0 FROM gfw_viirs_alerts LIMIT 1 OFFSET 1")
+            assert cursor.fetchone()[0] == "2024-10-31"


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-scripts-hub/issues/104.

## What I changed

* Adapting the GFW script to set the same date start and end fields as `alerts_googlecloud`, thus guaranteeing parity for purposes of the CoMapeo script and front ends. Note that this is a kind of workaround since GFW does not actually provide start and end detection data, but I think it's better to go about it this way than having separate data schemas and needing to support both downstream.