### PR TITLE
Add script to generate `azcopy` commands for downloading (or transferring) all file-based data

### DIFF
--- a/f/export/download_all_data/README.md
+++ b/f/export/download_all_data/README.md
@@ -1,6 +1,6 @@
 # 📦 Download all data (aka "Exit Plan")
 
-As part of our commitment to data sovereignty, we want to ensure that users of GuardianConnector can retrieve their data at any time.
+As part of our commitment to data sovereignty, we want to ensure that users of Guardian Connector can retrieve their data at any time.
 
 The scripts in this directory provide a basic implementation of such an "exit plan" — a way for users to download the contents of their **project data**. They do not currently include exports of things like:
 
@@ -18,17 +18,31 @@ This export script targets **project-specific tabular data** stored in the `ware
 - Tables ingested via connector scripts (e.g., Kobo, Comapeo, alerts)
 - Manually uploaded tabular data
 
-These tables are exported as CSV files, zipped into a single `.zip` archive, and saved to a volume mount location accessible to the user (e.g. `/persistent-storage/datalake/exports/`).
+These tables are exported as CSV files, zipped into a single `.zip` archive, and saved to a volume mount location accessible to the user (e.g. `/persistent-storage/datalake/exports/`). From there, the archive can be downloaded using a tool like [Filebrowser](https://filebrowser.org/) or exported alongside other files via the `download_all_files_azure` script (assuming files are stored in an Azure storage blob).
+
+## `download_all_files_azure`
+
+This export script targets **file-based data** stored in Azure Blob Storage containers:
+
+- Uploaded files (images, documents, media)
+- Exported data files from other services
+- Any persistent storage files accessible via Azure Blob Storage
+
+The script generates a secure SAS (Shared Access Signature) URL with time-limited access to the specified Azure Blob Storage container or subfolder. It then provides multiple [`azcopy`](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10?tabs=dnf) command options for different destinations (local disk, AWS S3, Google Cloud Storage, and another Azure Storage account)
+
+This approach using `azcopy` provides several advantages. Transfers are fast, especially when copying data directly between cloud services. You can choose from a variety of destinations for your data, making the process flexible. Because files are transferred directly from Azure storage, there is no additional load on your Guardian Connector deployment. Additionally, if a transfer is interrupted, the `azcopy` tool allows you to resume it without starting over.
+
+The generated SAS URL has a configurable expiry time (default 120 minutes) for security.
 
 ## Usage Notes
 
-- These scripts is intended to be run from **within an active GuardianConnector deployment**, using Windmill.
+- These scripts are intended to be run from **within an active Guardian Connector deployment**, using Windmill.
 - Users should be advised **not to run exports while new data is actively being posted** to the warehouse, to avoid inconsistent snapshots.
-- Archives are stored under `/persistent-storage/datalake/exports/` by default and can be accessed for download from there, using a tool like [Filebrowser](https://filebrowser.org/).
 
 ## Next Steps
 
 Potential planned future improvements include:
 
-- Streaming archive output to object storage (e.g., S3 or Azure Blob)
-- Optionally including datalake file attachments in the archive
+- Streaming Postgres archive output to blob storage
+- A Windmill app to improve the user experience of downloading data
+- Export scripts for file-based data stored in other storage systems (AWS S3, Google Cloud Storage, local file systems, etc.), as needed 

--- a/f/export/download_all_data/README.md
+++ b/f/export/download_all_data/README.md
@@ -28,7 +28,12 @@ This export script targets **file-based data** stored in Azure Blob Storage cont
 - Exported data files from other services
 - Any persistent storage files accessible via Azure Blob Storage
 
-The script generates a secure SAS (Shared Access Signature) URL with time-limited access to the specified Azure Blob Storage container or subfolder. It then provides multiple [`azcopy`](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10?tabs=dnf) command options for different destinations (local disk, AWS S3, Google Cloud Storage, and another Azure Storage account)
+The script generates a secure SAS (Shared Access Signature) URL with time-limited access to the specified Azure Blob Storage container or subfolder. It then provides multiple [`azcopy`](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10?tabs=dnf) command options for different destinations:
+
+- Local disk (download to your computer)
+- AWS S3 bucket (cloud-to-cloud transfer)
+- Google Cloud Storage (cloud-to-cloud transfer)
+- Another Azure Storage account (cloud-to-cloud transfer)
 
 This approach using `azcopy` provides several advantages. Transfers are fast, especially when copying data directly between cloud services. You can choose from a variety of destinations for your data, making the process flexible. Because files are transferred directly from Azure storage, there is no additional load on your Guardian Connector deployment. Additionally, if a transfer is interrupted, the `azcopy` tool allows you to resume it without starting over.
 

--- a/f/export/download_all_data/download_all_files_azure.py
+++ b/f/export/download_all_data/download_all_files_azure.py
@@ -1,0 +1,92 @@
+import logging
+from datetime import datetime, timedelta
+
+from azure.storage.blob import (
+    BlobServiceClient,
+    ContainerSasPermissions,
+    generate_container_sas,
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def main(
+    blob_connection_string: str,
+    container_name: str,
+    folder_path: str = "",
+    expiry_minutes: int = 120,
+):
+    """
+    Generate a SAS URL for an Azure Blob Storage container or subfolder,
+    allowing the user to run an `azcopy` command to download all files directly
+    from persistent storage. Ideal for creating a fast and reliable file
+    download option without requiring zipping large directories.
+
+    Returns:
+        dict: Dictionary containing the generated azcopy commands for different destinations
+    """
+
+    try:
+        blob_service_client = BlobServiceClient.from_connection_string(
+            blob_connection_string
+        )
+        account_name = blob_service_client.account_name
+
+        # Generate the SAS token
+        sas_token = generate_container_sas(
+            account_name=account_name,
+            container_name=container_name,
+            account_key=blob_service_client.credential.account_key,
+            permission=ContainerSasPermissions(read=True, list=True),
+            expiry=datetime.utcnow() + timedelta(minutes=expiry_minutes),
+        )
+
+        base_url = f"https://{account_name}.blob.core.windows.net/{container_name}"
+        if folder_path:
+            folder_path = folder_path.strip("/")
+            full_url = f"{base_url}/{folder_path}?{sas_token}"
+        else:
+            full_url = f"{base_url}?{sas_token}"
+
+        # Create command dictionary
+        commands = {
+            "local": f"azcopy copy '{full_url}' './downloaded_data/' --recursive",
+            "s3": f"azcopy copy '{full_url}' 's3://your-bucket-name/downloaded_data/' --recursive",
+            "gcs": f"azcopy copy '{full_url}' 'gs://your-bucket-name/downloaded_data/' --recursive",
+            "azure": f"azcopy copy '{full_url}' 'https://youraccount.blob.core.windows.net/yourcontainer/downloaded_data/' --recursive",
+        }
+
+        # Print multiple destination options
+        # This is a temporary solution to return the commands to the user
+        # In the future, we might want to provide the commands in a Windmill app or something else
+        print(
+            "✅ Choose your preferred download destination and run the corresponding command from your terminal:"
+        )
+        print(" ")
+
+        print("📁 **Download to local disk:**")
+        print(commands["local"])
+        print(" ")
+        print("☁️ **Copy to AWS S3 bucket:**")
+        print(commands["s3"])
+        print("   (Requires AWS credentials configured: aws configure)")
+        print(" ")
+        print("🌐 **Copy to Google Cloud Storage:**")
+        print(commands["gcs"])
+        print("   (Requires Google Cloud credentials: gcloud auth login)")
+        print(" ")
+        print("💾 **Copy to another Azure Storage account:**")
+        print(commands["azure"])
+        print("   (Requires destination storage account credentials)")
+        print(" ")
+        print(f"⏰ **Note:** This SAS URL will expire in {expiry_minutes} minutes")
+        print(
+            "📖 **Documentation and installation instructions:** https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10"
+        )
+
+        return commands
+
+    except Exception as e:
+        logger.error("Failed to generate SAS URL or azcopy command.")
+        raise e

--- a/f/export/download_all_data/download_all_files_azure.py
+++ b/f/export/download_all_data/download_all_files_azure.py
@@ -18,13 +18,26 @@ def main(
     expiry_minutes: int = 120,
 ):
     """
-    Generate a SAS URL for an Azure Blob Storage container or subfolder,
-    allowing the user to run an `azcopy` command to download all files directly
-    from persistent storage. Ideal for creating a fast and reliable file
-    download option without requiring zipping large directories.
+    Generate a SAS URL for an Azure Blob Storage container or subfolder and provide
+    azcopy commands for transferring files to multiple destinations
+    (local disk, AWS S3, Google Cloud Storage, and another Azure Storage account).
 
-    Returns:
-        dict: Dictionary containing the generated azcopy commands for different destinations
+    Parameters
+    ----------
+    blob_connection_string : str
+        The connection string for the Azure Blob Storage container.
+    container_name : str
+        The name of the Azure Blob Storage container.
+    folder_path : str, optional
+        The path to the subfolder within the container.
+    expiry_minutes : int, optional
+        The number of minutes before the SAS URL expires (default: 120)
+
+    Returns
+    -------
+    dict
+        Dictionary with keys 'local', 's3', 'gcs', 'azure' containing
+        the corresponding azcopy commands for each destination
     """
 
     try:

--- a/f/export/download_all_data/download_all_files_azure.script.lock
+++ b/f/export/download_all_data/download_all_files_azure.script.lock
@@ -1,0 +1,1 @@
+azure-storage-blob==12.19.0

--- a/f/export/download_all_data/download_all_files_azure.script.yaml
+++ b/f/export/download_all_data/download_all_files_azure.script.yaml
@@ -1,0 +1,48 @@
+summary: 'Export: Generate commands for downloading all files from Azure Blob Storage'
+description: >-
+  This script generates a SAS URL for an Azure Blob Storage container or subfolder
+  and provides multiple `azcopy` command options for different destinations:
+  local disk, AWS S3, Google Cloud Storage, or another Azure Storage account.
+  Ideal for creating fast and reliable file transfer options without requiring
+  zipping large directories or putting load on your GC deployment.
+
+lock: '!inline f/export/download_all_files_azure/download_all_files_azure.script.lock'
+concurrency_time_window_s: 0
+kind: script
+
+schema:
+  $schema: 'https://json-schema.org/draft/2020-12/schema'
+  type: object
+  order:
+    - blob_connection_string
+    - container_name
+    - folder_path
+    - expiry_minutes
+  properties:
+    blob_connection_string:
+      type: string
+      description: >-
+        Azure Storage connection string for accessing the blob storage account.
+        Format:
+        "DefaultEndpointsProtocol=https;AccountName=youracct;AccountKey=yourkey;EndpointSuffix=core.windows.net"
+      format: password
+    container_name:
+      type: string
+      description: >-
+        The name of the Azure Blob Storage container (e.g., "datalake").
+        This should match one of the containers visible in the Azure portal.
+      pattern: '^[a-z0-9\-]+$'
+    folder_path:
+      type: string
+      description: >-
+        Optional subfolder path within the container to restrict access.
+        Leave blank to expose the entire container.
+      default: ""
+    expiry_minutes:
+      type: integer
+      description: >-
+        How many minutes the generated SAS URL will remain valid.
+      default: 120
+  required:
+    - blob_connection_string
+    - container_name

--- a/f/export/download_all_data/download_all_files_azure.script.yaml
+++ b/f/export/download_all_data/download_all_files_azure.script.yaml
@@ -6,7 +6,7 @@ description: >-
   Ideal for creating fast and reliable file transfer options without requiring
   zipping large directories or putting load on your GC deployment.
 
-lock: '!inline f/export/download_all_files_azure/download_all_files_azure.script.lock'
+lock: '!inline f/export/download_all_files/download_all_files_azure.script.lock'
 concurrency_time_window_s: 0
 kind: script
 
@@ -14,24 +14,16 @@ schema:
   $schema: 'https://json-schema.org/draft/2020-12/schema'
   type: object
   order:
-    - blob_connection_string
-    - container_name
+    - azure_blob
     - folder_path
     - expiry_minutes
   properties:
-    blob_connection_string:
-      type: string
+    azure_blob:
+      type: object
       description: >-
-        Azure Storage connection string for accessing the blob storage account.
-        Format:
-        "DefaultEndpointsProtocol=https;AccountName=youracct;AccountKey=yourkey;EndpointSuffix=core.windows.net"
-      format: password
-    container_name:
-      type: string
-      description: >-
-        The name of the Azure Blob Storage container (e.g., "datalake").
-        This should match one of the containers visible in the Azure portal.
-      pattern: '^[a-z0-9\-]+$'
+        Windmill Azure Blob Storage resource containing account information
+        and credentials for accessing the storage account.
+      format: resource-azure_blob
     folder_path:
       type: string
       description: >-
@@ -44,5 +36,4 @@ schema:
         How many minutes the generated SAS URL will remain valid.
       default: 120
   required:
-    - blob_connection_string
-    - container_name
+    - azure_blob

--- a/f/export/download_all_data/tests/download_all_files_azure_test.py
+++ b/f/export/download_all_data/tests/download_all_files_azure_test.py
@@ -1,21 +1,23 @@
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from f.export.download_all_data.download_all_files_azure import main
 
 
 @patch("f.export.download_all_data.download_all_files_azure.generate_container_sas")
-@patch("f.export.download_all_data.download_all_files_azure.BlobServiceClient")
-def test_basic_output(mock_blob_service_client, mock_generate_sas):
+def test_basic_output(mock_generate_sas):
     """Test that all expected azcopy commands are returned"""
-
-    # Mock Azure SDK
-    mock_client = Mock()
-    mock_client.account_name = "testaccount"
-    mock_client.credential.account_key = "testkey"
-    mock_blob_service_client.from_connection_string.return_value = mock_client
     mock_generate_sas.return_value = "test_sas_token"
 
-    commands = main("test_connection_string", "testcontainer")
+    # Create mock azure_blob resource
+    azure_blob = {
+        "accountName": "testaccount",
+        "containerName": "testcontainer",
+        "accessKey": "testkey",
+        "useSSL": True,
+        "endpoint": "core.windows.net",
+    }
+
+    commands = main(azure_blob)
 
     # Check that all destination options are present
     assert "local" in commands
@@ -46,19 +48,20 @@ def test_basic_output(mock_blob_service_client, mock_generate_sas):
 
 
 @patch("f.export.download_all_data.download_all_files_azure.generate_container_sas")
-@patch("f.export.download_all_data.download_all_files_azure.BlobServiceClient")
-def test_with_folder_path(mock_blob_service_client, mock_generate_sas):
+def test_with_folder_path(mock_generate_sas):
     """Test that folder path is included in URLs"""
-
-    # Mock Azure SDK
-    mock_client = Mock()
-    mock_client.account_name = "testaccount"
-    mock_client.credential.account_key = "testkey"
-    mock_blob_service_client.from_connection_string.return_value = mock_client
     mock_generate_sas.return_value = "test_sas_token"
 
-    # Get returned commands with folder path
-    commands = main("test_connection_string", "testcontainer", "data/exports")
+    # Create mock azure_blob resource
+    azure_blob = {
+        "accountName": "testaccount",
+        "containerName": "testcontainer",
+        "accessKey": "testkey",
+        "useSSL": True,
+        "endpoint": "core.windows.net",
+    }
+
+    commands = main(azure_blob, "data/exports")
 
     # Check that folder path is included in URL
     expected_url = "https://testaccount.blob.core.windows.net/testcontainer/data/exports?test_sas_token"

--- a/f/export/download_all_data/tests/download_all_files_azure_test.py
+++ b/f/export/download_all_data/tests/download_all_files_azure_test.py
@@ -1,0 +1,68 @@
+from unittest.mock import Mock, patch
+
+from f.export.download_all_data.download_all_files_azure import main
+
+
+@patch("f.export.download_all_data.download_all_files_azure.generate_container_sas")
+@patch("f.export.download_all_data.download_all_files_azure.BlobServiceClient")
+def test_basic_output(mock_blob_service_client, mock_generate_sas):
+    """Test that all expected azcopy commands are returned"""
+
+    # Mock Azure SDK
+    mock_client = Mock()
+    mock_client.account_name = "testaccount"
+    mock_client.credential.account_key = "testkey"
+    mock_blob_service_client.from_connection_string.return_value = mock_client
+    mock_generate_sas.return_value = "test_sas_token"
+
+    commands = main("test_connection_string", "testcontainer")
+
+    # Check that all destination options are present
+    assert "local" in commands
+    assert "s3" in commands
+    assert "gcs" in commands
+    assert "azure" in commands
+
+    # Check that azcopy commands are formatted correctly
+    expected_url = (
+        "https://testaccount.blob.core.windows.net/testcontainer?test_sas_token"
+    )
+    assert (
+        commands["local"]
+        == f"azcopy copy '{expected_url}' './downloaded_data/' --recursive"
+    )
+    assert (
+        commands["s3"]
+        == f"azcopy copy '{expected_url}' 's3://your-bucket-name/downloaded_data/' --recursive"
+    )
+    assert (
+        commands["gcs"]
+        == f"azcopy copy '{expected_url}' 'gs://your-bucket-name/downloaded_data/' --recursive"
+    )
+    assert (
+        commands["azure"]
+        == f"azcopy copy '{expected_url}' 'https://youraccount.blob.core.windows.net/yourcontainer/downloaded_data/' --recursive"
+    )
+
+
+@patch("f.export.download_all_data.download_all_files_azure.generate_container_sas")
+@patch("f.export.download_all_data.download_all_files_azure.BlobServiceClient")
+def test_with_folder_path(mock_blob_service_client, mock_generate_sas):
+    """Test that folder path is included in URLs"""
+
+    # Mock Azure SDK
+    mock_client = Mock()
+    mock_client.account_name = "testaccount"
+    mock_client.credential.account_key = "testkey"
+    mock_blob_service_client.from_connection_string.return_value = mock_client
+    mock_generate_sas.return_value = "test_sas_token"
+
+    # Get returned commands with folder path
+    commands = main("test_connection_string", "testcontainer", "data/exports")
+
+    # Check that folder path is included in URL
+    expected_url = "https://testaccount.blob.core.windows.net/testcontainer/data/exports?test_sas_token"
+    assert (
+        commands["local"]
+        == f"azcopy copy '{expected_url}' './downloaded_data/' --recursive"
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ commands =
 [testenv:download_all_data]
 deps =
     -r{toxinidir}/f/export/download_all_data/download_all_postgres_data.script.lock
+    -r{toxinidir}/f/export/download_all_data/download_all_files_azure.script.lock
     -r{toxinidir}/f/export/download_all_data/tests/requirements-test.txt
 commands =
     pytest {posargs} f/export/download_all_data


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-scripts-hub/issues/95. (I don't think we're done with Exit Plan overall, not even in Windmill itself, but I am satisfied with the two scripts that have been added to close this issue.)

## Screenshots

<img width="668" height="523" alt="image" src="https://github.com/user-attachments/assets/14426414-a600-465a-a8c7-f5e9636a4606" />

## What I changed

* Adds a basic script to generate a SAS URL for an Azure Blob Storage container, and return several `azcopy` commands for different download destinations (local, AWS, GCP, Azure). The commands are also printed in the terminal as shown.
* Added tests.
* Expanded the `download_all_data` readme to discuss this script and some possible future directions.

## What I'm not doing here

* Wrapping it into an app experience as @IamJeffG suggested in https://github.com/ConservationMetrics/gc-scripts-hub/issues/95#issuecomment-3050094923. I like that idea but my brain isn't in Windmill app development at the moment, and the script itself has an inherent value-add.
