### PR TITLE
Allow user to set `alerts_provider`; don't override existing provider

### DIFF
--- a/f/connectors/alerts/alerts_gcs.py
+++ b/f/connectors/alerts/alerts_gcs.py
@@ -385,7 +385,6 @@ def prepare_alerts_metadata(alerts_metadata, territory_id, alerts_provider):
         index=False,
     )
 
-    # TODO: if this changes for future alerts, we will need to ensure that existing records are not overwritten.
     filtered_df["data_source"] = alerts_provider
 
     # Replace all NaN values with None

--- a/f/connectors/alerts/alerts_gcs.script.yaml
+++ b/f/connectors/alerts/alerts_gcs.script.yaml
@@ -9,6 +9,7 @@ schema:
   order:
     - gcp_service_acct
     - alerts_bucket
+    - alerts_provider
     - territory_id
     - db
     - db_table_name
@@ -17,6 +18,11 @@ schema:
     alerts_bucket:
       type: string
       description: The name of the Google Cloud Storage bucket where the alerts are stored.
+      default: null
+      originalType: string
+    alerts_provider:
+      type: string
+      description: The name of the alerts provider.
       default: null
       originalType: string
     db:
@@ -56,6 +62,7 @@ schema:
   required:
     - gcp_service_acct
     - alerts_bucket
+    - alerts_provider
     - territory_id
     - db
     - db_table_name

--- a/f/connectors/alerts/tests/alerts_gcs_test.py
+++ b/f/connectors/alerts/tests/alerts_gcs_test.py
@@ -26,7 +26,7 @@ def test_prepare_alerts_metadata():
     alerts_metadata = pd.read_csv(alerts_history_csv).to_csv(index=False)
 
     prepared_alerts_metadata, alert_statistics = prepare_alerts_metadata(
-        alerts_metadata, 100
+        alerts_metadata, 100, "test_provider"
     )
 
     # Check that alerts statistics is the latest month and year in the CSV
@@ -39,8 +39,8 @@ def test_metadata_id_stability():
     alerts_history_csv = Path(assets_directory, "alerts_history.csv")
     alerts_metadata = pd.read_csv(alerts_history_csv).to_csv(index=False)
 
-    first, _ = prepare_alerts_metadata(alerts_metadata, 100)
-    second, _ = prepare_alerts_metadata(alerts_metadata, 100)
+    first, _ = prepare_alerts_metadata(alerts_metadata, 100, "test_provider")
+    second, _ = prepare_alerts_metadata(alerts_metadata, 100, "test_provider")
 
     # Order shouldn't matter but just to be safe, sort by _id
     first_ids = sorted(r["_id"] for r in first)
@@ -53,7 +53,7 @@ def test_metadata_id_stability():
 def test_alert_id_generation(tmp_path):
     file_path = Path(assets_directory, "alert_202309900112345671.geojson")
     geojson_files = [str(file_path)]
-    prepared = prepare_alerts_data(tmp_path, geojson_files)
+    prepared = prepare_alerts_data(tmp_path, geojson_files, "test_provider")
 
     assert len(prepared) > 0
     for row in prepared:
@@ -99,6 +99,7 @@ def test_script_e2e(pg_database, mock_alerts_storage_client, tmp_path):
     alerts_metadata = _main(
         mock_alerts_storage_client,
         MOCK_BUCKET_NAME,
+        "test_provider",
         100,
         pg_database,
         "fake_alerts",
@@ -248,6 +249,7 @@ def test_script_e2e(pg_database, mock_alerts_storage_client, tmp_path):
     alerts_metadata = _main(
         mock_alerts_storage_client,
         MOCK_BUCKET_NAME,
+        "test_provider",
         100,
         pg_database,
         "fake_alerts",
@@ -264,6 +266,7 @@ def test_file_update_logic(pg_database, mock_alerts_storage_client, tmp_path):
     _main(
         mock_alerts_storage_client,
         MOCK_BUCKET_NAME,
+        "test_provider",
         100,
         pg_database,
         "fake_alerts",
@@ -278,6 +281,7 @@ def test_file_update_logic(pg_database, mock_alerts_storage_client, tmp_path):
     _main(
         mock_alerts_storage_client,
         MOCK_BUCKET_NAME,
+        "test_provider",
         100,
         pg_database,
         "fake_alerts",
@@ -304,6 +308,7 @@ def test_file_update_logic(pg_database, mock_alerts_storage_client, tmp_path):
     _main(
         mock_alerts_storage_client,
         MOCK_BUCKET_NAME,
+        "test_provider",
         100,
         pg_database,
         "fake_alerts",

--- a/f/connectors/alerts_download_post_notify.flow/flow.yaml
+++ b/f/connectors/alerts_download_post_notify.flow/flow.yaml
@@ -11,6 +11,9 @@ value:
           alerts_bucket:
             type: javascript
             expr: flow_input.alerts_bucket
+          alerts_provider:
+            type: javascript
+            expr: flow_input.alerts_provider
           db:
             type: javascript
             expr: flow_input.db
@@ -87,6 +90,11 @@ schema:
       description: The name of the Google Cloud Storage bucket where the alerts are stored.
       default: ''
       originalType: string
+    alerts_provider:
+      type: string
+      description: The name of the alerts provider.
+      default: null
+      originalType: string
     comapeo:
       type: object
       description: >
@@ -151,6 +159,7 @@ schema:
   required:
     - gcp_service_acct
     - alerts_bucket
+    - alerts_provider
     - territory_id
     - db
     - db_table_name


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-scripts-hub/issues/129.

To address this, I needed to introduce a fix to ensure that existing records are kept intact with the previously hard-coded provider.

Let's assume we had an alert with `data_source`="first_provider", and now we set `alerts_provider`="second provider".

**Before Fix:**
* Same alert + any provider → UUID: abc123
* New records get `data_source`="second_provider"
* Existing records _also_ get updated with `data_source`="second_provider"

**After Fix:**
* Same alert + any provider → UUID: abc123
* New records get `data_source`="second_provider"
* Existing records keep `data_source`="first_provider"

(And to be explicit: the reason we don't factor providers into hashing UUID's is to ensure that no records are duplicated if the alert provider changes.)

## What I changed

* Allow the Windmill user to set a parameter `alerts_provider` instead of hard-coding it as `data_source`
* Added a helper function `_get_existing_data_sources()` to retrieve existing `data_source` values for given alert IDs (hashed as UUID) from the DB.
* In `prepare_alerts_metadata()`, compare incoming `data_source` (set via `alerts_provider` param) with existing database values. If an existing record is found, preserve its original `data_source` value. Only new records get the current `alerts_provider` value.
* Added tests to verify this behavior.
* Updated the Alerts Flow as well.