### PR TITLE
Add CSV to Postgres script

### DIFF
--- a/f/connectors/csv/README.md
+++ b/f/connectors/csv/README.md
@@ -1,0 +1,30 @@
+# `csv_to_postgres`: Import a CSV file into a PostgreSQL table
+
+This script reads a CSV file and inserts its contents into a PostgreSQL table, treating all data as TEXT columns.
+
+### Behavior
+
+* Each CSV column is inserted as-is into a database column with the same name.
+  
+  Example: CSV column `name` → database column `name`
+
+* An `_id` primary key column is automatically added:
+  - If `id_column` parameter is specified and exists in the CSV, that column's values are used as `_id` and the original column is removed
+  - If no `id_column` is specified, auto-incrementing row numbers (1, 2, 3...) are used as `_id`
+
+* All data is stored as TEXT fields for simplicity and consistency.
+
+### Parameters
+
+* `csv_path`: Path to the CSV file to import
+* `db_table_name`: Name of the PostgreSQL table to create/insert into
+* `id_column` (optional): Name of existing CSV column to use as primary key
+* `delete_csv_file` (optional): Whether to delete the CSV file after import
+* `attachment_root` (optional): Root directory where CSV file is located
+
+### Notes
+
+* The CSV file must have headers in the first row
+* All values are treated as TEXT regardless of their apparent type
+* Optionally, the input file is deleted after import
+* If the specified `id_column` doesn't exist in the CSV, auto-incrementing IDs are used instead

--- a/f/connectors/csv/csv_to_postgres.py
+++ b/f/connectors/csv/csv_to_postgres.py
@@ -1,0 +1,112 @@
+# requirements:
+# psycopg2-binary
+
+import csv
+import logging
+from pathlib import Path
+
+from f.common_logic.db_operations import StructuredDBWriter, conninfo, postgresql
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def main(
+    db: postgresql,
+    db_table_name: str,
+    csv_path: str,
+    attachment_root: str = "/persistent-storage/datalake/",
+    delete_csv_file: bool = False,
+    id_column: str = None,
+):
+    """
+    Import CSV data into PostgreSQL table.
+
+    Parameters
+    ----------
+    db : postgresql
+        Database connection object.
+    db_table_name : str
+        Name of the database table to create/insert into.
+    csv_path : str
+        Path to the CSV file to import.
+    attachment_root : str
+        Root directory where CSV file is located.
+    delete_csv_file : bool
+        Whether to delete the CSV file after processing.
+    id_column : str, optional
+        Name of column to use as primary key. If None, auto-generates _id.
+    """
+    csv_path = Path(attachment_root) / Path(csv_path)
+    transformed_csv_data = transform_csv_data(csv_path, id_column)
+
+    db_writer = StructuredDBWriter(
+        conninfo(db),
+        db_table_name,
+        use_mapping_table=False,
+        reverse_properties_separated_by=None,
+    )
+    db_writer.handle_output(transformed_csv_data)
+
+    if delete_csv_file:
+        delete_csv_file(csv_path)
+
+
+def transform_csv_data(csv_path, id_column=None):
+    """
+    Transform CSV data into a list of dictionaries suitable for database insertion.
+
+    Parameters
+    ----------
+    csv_path : str or Path
+        Path to the CSV file to read.
+    id_column : str, optional
+        Name of column to use as primary key. If None, auto-generates _id.
+
+    Returns
+    -------
+    list
+        List of dictionaries where each dictionary represents a CSV row with keys
+        matching column names, and an '_id' field for the primary key.
+    """
+    with open(csv_path, "r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    transformed_csv_data = []
+    for idx, row in enumerate(rows, 1):
+        # Use specified column as _id, or generate auto-incrementing _id
+        if id_column and id_column in row:
+            row_id = row[id_column]
+            # Remove the original id column since we're using it as _id
+            if id_column != "_id":
+                del row[id_column]
+        else:
+            row_id = str(idx)
+
+        transformed_row = {
+            "_id": row_id,
+            **row,
+        }
+        transformed_csv_data.append(transformed_row)
+
+    return transformed_csv_data
+
+
+def delete_csv_file(csv_path: Path):
+    """
+    Delete the CSV file after processing.
+
+    Parameters
+    ----------
+    csv_path : Path
+        Path to the CSV file to delete.
+    """
+    try:
+        csv_path.unlink()
+        logger.info(f"Deleted CSV file: {csv_path}")
+    except FileNotFoundError:
+        logger.warning(f"CSV file not found: {csv_path}")
+    except Exception as e:
+        logger.error(f"Error deleting CSV file: {e}")
+        raise

--- a/f/connectors/csv/csv_to_postgres.script.lock
+++ b/f/connectors/csv/csv_to_postgres.script.lock
@@ -1,0 +1,1 @@
+psycopg2-binary==2.9.10

--- a/f/connectors/csv/csv_to_postgres.script.yaml
+++ b/f/connectors/csv/csv_to_postgres.script.yaml
@@ -1,0 +1,53 @@
+summary: 'CSV: Upload to Postgres'
+description: This script uploads CSV data to a Postgres database.
+lock: '!inline f/connectors/csv/csv_to_postgres.script.lock'
+concurrency_time_window_s: 0
+kind: script
+schema:
+  $schema: 'https://json-schema.org/draft/2020-12/schema'
+  type: object
+  order:
+    - csv_path
+    - db
+    - db_table_name
+    - id_column
+    - delete_csv_file
+    - attachment_root
+  properties:
+    attachment_root:
+      type: string
+      description: >-
+        A path where to find the CSV file.
+      default: /persistent-storage/datalake
+      originalType: string
+    db:
+      type: object
+      description: A database connection for storing tabular data.
+      default: null
+      format: resource-postgresql
+    db_table_name:
+      type: string
+      description: The name of the database table where the data will be stored.
+      default: null
+      originalType: string
+      pattern: '^.{1,54}$'
+    id_column:
+      type: string
+      description: >-
+        Name of the column to use as primary key. If not specified, 
+        auto-generates _id with row numbers.
+      default: null
+      originalType: string
+    delete_csv_file:
+      type: boolean
+      description: Whether to delete the CSV file after processing.
+      default: false
+    csv_path:
+      type: string
+      description: The path to the CSV file to upload, including the filename.
+      default: null
+      originalType: string
+  required:
+    - csv_path
+    - db
+    - db_table_name

--- a/f/connectors/csv/tests/assets/data.csv
+++ b/f/connectors/csv/tests/assets/data.csv
@@ -1,0 +1,4 @@
+species_name,resource_use,ecosystem_type,availability_status
+Palm Tree A,Construction material,Lowland forest,Declining
+Fish Species B,Primary protein source,River system,Stable
+Timber Species C,Housing and tools,Mountain forest,Critically low

--- a/f/connectors/csv/tests/assets/data_with_id.csv
+++ b/f/connectors/csv/tests/assets/data_with_id.csv
@@ -1,0 +1,3 @@
+plot_id,land_use_type,resource_density
+PLT001,Agroforestry system,High productivity
+PLT002,Selective logging area,Moderate depletion

--- a/f/connectors/csv/tests/conftest.py
+++ b/f/connectors/csv/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+import testing.postgresql
+
+
+@pytest.fixture
+def pg_database():
+    """A dsn that may be used to connect to a live (local for test) postgresql server"""
+    db = testing.postgresql.Postgresql(port=7654)
+    dsn = db.dsn()
+    dsn["dbname"] = dsn.pop("database")
+    yield dsn
+    db.stop()

--- a/f/connectors/csv/tests/csv_to_postgres_test.py
+++ b/f/connectors/csv/tests/csv_to_postgres_test.py
@@ -1,0 +1,92 @@
+import psycopg2
+
+from f.connectors.csv.csv_to_postgres import main
+
+csv_fixture_path = "f/connectors/csv/tests/assets/"
+
+
+def test_script_e2e(pg_database):
+    main(pg_database, "my_csv_data", "data.csv", csv_fixture_path, False)
+
+    with psycopg2.connect(**pg_database) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT COUNT(*) FROM my_csv_data")
+            assert cursor.fetchone()[0] == 3
+
+            cursor.execute(
+                "SELECT _id, species_name, resource_use, ecosystem_type, availability_status FROM my_csv_data WHERE _id = '1'"
+            )
+            row_data = cursor.fetchone()
+            assert row_data == (
+                "1",
+                "Palm Tree A",
+                "Construction material",
+                "Lowland forest",
+                "Declining",
+            )
+
+            cursor.execute(
+                "SELECT _id, species_name, resource_use, ecosystem_type, availability_status FROM my_csv_data WHERE _id = '2'"
+            )
+            row_data = cursor.fetchone()
+            assert row_data == (
+                "2",
+                "Fish Species B",
+                "Primary protein source",
+                "River system",
+                "Stable",
+            )
+
+            cursor.execute(
+                "SELECT _id, species_name, resource_use, ecosystem_type, availability_status FROM my_csv_data WHERE _id = '3'"
+            )
+            row_data = cursor.fetchone()
+            assert row_data == (
+                "3",
+                "Timber Species C",
+                "Housing and tools",
+                "Mountain forest",
+                "Critically low",
+            )
+
+            # Check that there is no __columns table created
+            cursor.execute(
+                "SELECT * FROM information_schema.tables WHERE table_name = 'my_csv_data__columns'"
+            )
+            assert cursor.fetchone() is None
+
+
+def test_script_with_custom_id_column(pg_database):
+    main(
+        pg_database,
+        "my_csv_data_custom_id",
+        "data_with_id.csv",
+        csv_fixture_path,
+        False,
+        "plot_id",
+    )
+
+    with psycopg2.connect(**pg_database) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT COUNT(*) FROM my_csv_data_custom_id")
+            assert cursor.fetchone()[0] == 2
+
+            cursor.execute(
+                "SELECT _id, land_use_type, resource_density FROM my_csv_data_custom_id WHERE _id = 'PLT001'"
+            )
+            row_data = cursor.fetchone()
+            assert row_data == (
+                "PLT001",
+                "Agroforestry system",
+                "High productivity",
+            )
+
+            cursor.execute(
+                "SELECT _id, land_use_type, resource_density FROM my_csv_data_custom_id WHERE _id = 'PLT002'"
+            )
+            row_data = cursor.fetchone()
+            assert row_data == (
+                "PLT002",
+                "Selective logging area",
+                "Moderate depletion",
+            )

--- a/f/connectors/csv/tests/requirements-test.txt
+++ b/f/connectors/csv/tests/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest
+testing.postgresql

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-env_list = alerts, arcgis, auditor2, common_logic, comapeo, download_all_data, geojson, globalforestwatch, kobotoolbox_responses, locusmap, odk_responses, postgres_to_file, timelapse
+env_list = alerts, arcgis, auditor2, common_logic, comapeo, csv, download_all_data, geojson, globalforestwatch, kobotoolbox_responses, locusmap, odk_responses, postgres_to_file, timelapse
 
 [testenv]
 setenv =
@@ -63,6 +63,13 @@ deps =
     -r{toxinidir}/f/export/download_all_data/tests/requirements-test.txt
 commands =
     pytest {posargs} f/export/download_all_data
+
+[testenv:csv]
+deps =
+    -r{toxinidir}/f/connectors/csv/csv_to_postgres.script.lock
+    -r{toxinidir}/f/connectors/csv/tests/requirements-test.txt
+commands =
+    pytest {posargs} f/connectors/csv
 
 [testenv:geojson]
 deps =


### PR DESCRIPTION
## Goal

Towards https://github.com/ConservationMetrics/gc-scripts-hub/issues/117. Adds a script that reads a CSV file and inserts its contents into a PostgreSQL table.

This one should be straightforward and follows a similar pattern of changes as numerous scripts in the past, so I won't go into a lot of detail in this PR description. I might suggest looking at how ids are handled.