### PR TITLE
Improve error handling for GFW

### DIFF
--- a/f/connectors/globalforestwatch/README.md
+++ b/f/connectors/globalforestwatch/README.md
@@ -9,6 +9,8 @@ Currently, we support fetching the following alerts from GFW:
 * [RADD alerts](https://data.globalforestwatch.org/datasets/gfw::deforestation-alerts-radd/about)
 * [NASA VIIRS fire alerts](https://data.globalforestwatch.org/documents/gfw::viirs-active-fires/about)
 
+You can use these scripts to download data from GFW for your own analytical purposes, or to visualize them in a tool like QGIS or [Guardian Connector Explorer](https://github.com/conservationmetrics/gc-explorer). Please note that if you intend to use GC Explorer's Alert Dashboard view, your dataset should be relatively small (recommended: less than 1000 alerts). Datasets like deforestation alerts can be quite large depending on the area of interest and the time period, and may not be suitable for the Alert Dashboard view which is designed for smaller datasets.
+
 > [!NOTE]
 > This script makes a query request to conduct on-the-fly data analysis. This means that for large areas, it may take a while for the GFW API to return the result. Additionally, there is a **maximum allowed payload size of 6291556 bytes**.
 >

--- a/f/connectors/globalforestwatch/gfw_alerts.py
+++ b/f/connectors/globalforestwatch/gfw_alerts.py
@@ -108,7 +108,18 @@ def fetch_alerts_from_gfw(
     }
 
     response = requests.post(url, headers=headers, json=data)
-    response.raise_for_status()
+
+    if not response.ok:
+        # Try to get error message from response body
+        try:
+            error_body = response.json()
+            if isinstance(error_body, dict) and "message" in error_body:
+                logger.error(f"GFW API Error: {error_body['message']}")
+        except (ValueError, json.JSONDecodeError):
+            pass
+
+        response.raise_for_status()
+
     results = response.json().get("data", [])
 
     logger.info(f"Received {len(results)} alerts from GFW API.")

--- a/f/connectors/globalforestwatch/gfw_alerts.py
+++ b/f/connectors/globalforestwatch/gfw_alerts.py
@@ -110,7 +110,6 @@ def fetch_alerts_from_gfw(
     response = requests.post(url, headers=headers, json=data)
 
     if not response.ok:
-        # Try to get error message from response body
         try:
             error_body = response.json()
             if isinstance(error_body, dict) and "message" in error_body:


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-scripts-hub/issues/146.

With this, logs will output error messages in the expected format from GFW,like:

```
ERROR:f.connectors.globalforestwatch.gfw_alerts:GFW API Error: Raster analysis lambda received an unexpected response: {
  "errorMessage": "Response payload size exceeded maximum allowed payload size (6291556 bytes).",
  "errorType": "Function.ResponseSizeTooLarge"
}
```

I also added a note about the intended use of GFW alerts.