### PR TITLE
Permit null geometry for GeoJSON

### DIFF
--- a/f/common_logic/data_conversion.py
+++ b/f/common_logic/data_conversion.py
@@ -279,7 +279,10 @@ def read_geojson(path: Path):
     NOTE: this function uses manual parsing for better validation and error messages.
     Both fiona.open() and geojson.geometry.is_valid() are too permissive with invalid
     GeoJSON files - they focus on data extraction rather than format compliance (e.g. accept
-    empty features, missing properties, null geometries).
+    empty features, missing properties).
+
+    Features with null geometry are accepted as-is, as upstream sources sometimes
+    provide features with null geometry which should be preserved in the output.
 
     Returns
     -------
@@ -303,10 +306,17 @@ def read_geojson(path: Path):
             raise ValueError(f"Feature at index {i} is not a dictionary")
         if feature.get("type") != "Feature":
             raise ValueError(f"Feature at index {i} must have type 'Feature'")
-        if "geometry" not in feature or feature["geometry"] is None:
-            raise ValueError(f"Feature at index {i} missing geometry")
-        if not isinstance(feature["geometry"].get("coordinates"), list):
-            raise ValueError(f"Feature at index {i} has invalid geometry coordinates")
+        if "geometry" not in feature:
+            raise ValueError(f"Feature at index {i} missing geometry field")
+
+        # Accept null geometry as-is (upstream sources sometimes provide this)
+        geometry = feature["geometry"]
+        if geometry is not None:
+            if not isinstance(geometry.get("coordinates"), list):
+                raise ValueError(
+                    f"Feature at index {i} has invalid geometry coordinates"
+                )
+
         if "properties" not in feature or feature["properties"] is None:
             raise ValueError(f"Feature at index {i} missing properties")
 

--- a/f/common_logic/tests/conftest.py
+++ b/f/common_logic/tests/conftest.py
@@ -96,7 +96,41 @@ def geojson_with_invalid_geometry_file(tmp_path):
                 "geometry": {"type": "Point", "coordinates": "foo,bar"},
                 "properties": {},
             },
-            {"type": "Feature", "geometry": None, "properties": {"name": "ghost"}},
+            {
+                "type": "Feature", 
+                "geometry": {"type": "LineString", "coordinates": {"invalid": "structure"}},
+                "properties": {"name": "invalid_line"}
+            },
+        ],
+    }
+    path.write_text(json.dumps(data))
+    return path
+
+
+@pytest.fixture
+def geojson_with_null_geometry_file(tmp_path):
+    path = tmp_path / "null_geometry.geojson"
+    data = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "id": "valid_point_1",
+                "geometry": {"type": "Point", "coordinates": [1.0, 2.0]},
+                "properties": {"name": "valid_point"},
+            },
+            {
+                "type": "Feature", 
+                "id": "null_geometry_1",
+                "geometry": None, 
+                "properties": {"name": "null_geometry_feature"}
+            },
+            {
+                "type": "Feature",
+                "id": "valid_line_1",
+                "geometry": {"type": "LineString", "coordinates": [[1.0, 2.0], [3.0, 4.0]]},
+                "properties": {"name": "valid_line"},
+            },
         ],
     }
     path.write_text(json.dumps(data))


### PR DESCRIPTION
## Goal

Closes #148.

As @nicopace points out, there are many GeoJSON sources in the wild that, for some reason, have features with `"geometry": null`. At least one reason that I know of: sometimes mobile data collection apps like Mapeo have an error getting data from the GPS when creating a feature, and the fallback is to set geometry to `null`. In fact, I would say that I have seen this issue in pretty much all Mapeo datasets with >100 points that I remember having encountered. 

I agree with Nico that the desired behavior is to do what QGIS does, and just ignore those features when rendering on a Map. We do this already in `gc-explorer` and it's still worth representing those features in a different view, like a Gallery.

## What I changed

* In `read_geojson()`, don't raise a ValueError if geometry is null. But I still kept a check to raise an error if `geometry.coordinates` is not a list, as I haven't seen (yet) in the wild that `geometry` can set but not `coordinates`.
* Added a test case for this new behavior.