### PR TITLE
Pass DB table name to twilio, and change slug var name

### DIFF
--- a/f/connectors/alerts/alerts_gcs.py
+++ b/f/connectors/alerts/alerts_gcs.py
@@ -140,7 +140,14 @@ def _main(
     )
     metadata_written = metadata_writer.handle_output(prepared_alerts_metadata)
 
-    return alerts_statistics if alerts_data_written or metadata_written else None
+    return (
+        {
+            "alerts_statistics": alerts_statistics,
+            "db_table_name": db_table_name,
+        }
+        if alerts_data_written or metadata_written
+        else None
+    )
 
 
 def _get_rel_filepath(local_file_path, territory_id):

--- a/f/connectors/alerts/alerts_twilio.py
+++ b/f/connectors/alerts/alerts_twilio.py
@@ -24,13 +24,18 @@ logger = logging.getLogger(__name__)
 
 def main(
     alerts_statistics: dict,
-    community_slug: str,
+    instance_slug: str,
+    db_table_name: str,
     twilio_message_template: twilio_message_template,
 ):
-    send_twilio_message(twilio_message_template, alerts_statistics, community_slug)
+    send_twilio_message(
+        twilio_message_template, alerts_statistics, instance_slug, db_table_name
+    )
 
 
-def send_twilio_message(twilio_message_template, alerts_statistics, community_slug):
+def send_twilio_message(
+    twilio_message_template, alerts_statistics, instance_slug, db_table_name
+):
     """
     Send a Twilio SMS message with alerts processing completion details.
 
@@ -51,8 +56,10 @@ def send_twilio_message(twilio_message_template, alerts_statistics, community_sl
     alerts_statistics : dict
         A dictionary containing statistics about the processed alerts, such as
         the total number of alerts, month and year, and a description.
-    community_slug : str
-        The slug of the community for which alerts are being processed.
+    instance_slug : str
+        The slug of the instance for which alerts are being processed.
+    db_table_name : str
+        The name of the database table where alerts are stored.
     """
     client = TwilioClient(
         twilio_message_template["account_sid"], twilio_message_template["auth_token"]
@@ -71,7 +78,7 @@ def send_twilio_message(twilio_message_template, alerts_statistics, community_sl
                     "1": alerts_statistics.get("total_alerts"),
                     "2": alerts_statistics.get("month_year"),
                     "3": alerts_statistics.get("description_alerts"),
-                    "4": f"https://explorer.{community_slug}.guardianconnector.net/alerts/alerts",
+                    "4": f"https://explorer.{instance_slug}.guardianconnector.net/alerts/{db_table_name}",
                 }
             ),
             messaging_service_sid=twilio_message_template.get("messaging_service_sid"),

--- a/f/connectors/alerts/alerts_twilio.script.yaml
+++ b/f/connectors/alerts/alerts_twilio.script.yaml
@@ -8,8 +8,9 @@ schema:
   type: object
   order:
     - alerts_statistics
+    - instance_slug
+    - db_table_name
     - twilio_message_template
-    - community_slug
   properties:
     alerts_statistics:
       type: object
@@ -18,14 +19,21 @@ schema:
         description of alerts.
       default: null
       properties: {}
-    community_slug:
+    instance_slug:
       type: string
       description: >-
-        The URL slug for the community, used to construct a link to the alerts
+        The URL slug for the instance, used to construct a link to the alerts
         dashboard. This name is used for Twilio and must be provided for
         messages to be sent.
       default: null
       originalType: string
+    db_table_name:
+      type: string
+      description: >-
+        The name of the database table where alerts are stored.
+      default: null
+      originalType: string
+      pattern: '^.{1,53}$'
     twilio_message_template:
       type: object
       description: >-
@@ -36,5 +44,6 @@ schema:
       format: resource-twilio_message_template
   required:
     - alerts_statistics
-    - community_slug
+    - instance_slug
+    - db_table_name
     - twilio_message_template

--- a/f/connectors/alerts_download_post_notify.flow/flow.yaml
+++ b/f/connectors/alerts_download_post_notify.flow/flow.yaml
@@ -61,10 +61,13 @@ value:
         input_transforms:
           alerts_statistics:
             type: javascript
-            expr: results.a
-          community_slug:
+            expr: results.a.alerts_statistics
+          instance_slug:
             type: javascript
-            expr: flow_input.community_slug
+            expr: flow_input.instance_slug
+          db_table_name:
+            type: javascript
+            expr: results.a.db_table_name
           twilio_message_template:
             type: javascript
             expr: flow_input.twilio_message_template
@@ -72,7 +75,7 @@ value:
         path: f/connectors/alerts/alerts_twilio
       continue_on_error: false
       skip_if:
-        expr: '!flow_input.twilio_message_template || !flow_input.community_slug || !results.a'
+        expr: '!flow_input.twilio_message_template || !flow_input.instance_slug || !results.a || !results.a.alerts_statistics || !results.a.db_table_name'
 schema:
   $schema: 'https://json-schema.org/draft/2020-12/schema'
   type: object
@@ -87,7 +90,7 @@ schema:
     - destination_path
     - comapeo
     - comapeo_project
-    - community_slug
+    - instance_slug
     - twilio_message_template
   properties:
     alerts_bucket:
@@ -120,13 +123,14 @@ schema:
       description: A project ID on the CoMapeo server where the alerts will be posted.
       default: ''
       nullable: false
-    community_slug:
+    instance_slug:
       type: string
       description: >-
-        The URL slug for the community, used to construct a link to the alerts
-        dashboard. This name is used for Twilio and must be provided for
+        The URL slug for the instance, used to construct a link to the alerts
+        dashboard. This name is used for the instance and must be provided for
         messages to be sent.
       default: ''
+      originalType: string
       nullable: false
     db:
       type: object


### PR DESCRIPTION
## Goal

* Pass `db_table_name` to Twilio script so it can be used for the URL instead of hardcoded `/alerts/alerts`
* Change name of `community_slug` to `instance_slug` to clarify the meaning of this var.

NOTE: after merging and syncing, we will need to update each script to set a value for `instance_slug`.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None