### PR TITLE
Move slugify fn to `identifier_utils` module

### DIFF
--- a/f/common_logic/data_conversion.py
+++ b/f/common_logic/data_conversion.py
@@ -1,11 +1,8 @@
 import csv
 import json
 import logging
-import re
-import unicodedata
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import Any
 
 import filetype
 import fiona
@@ -673,32 +670,3 @@ def smart_xml_to_geojson(path: Path):
     from f.connectors.smart.smart_patrols import parse_smart_patrol_xml
 
     return parse_smart_patrol_xml(path)
-
-
-def slugify(value: Any, allow_unicode: bool = False) -> str:
-    """A safe slugify utility.
-
-    - Converts to str, normalizes unicode, optionally keeps unicode.
-    - Returns an ASCII-ish slug of the input suitable for file names.
-    - Returns 'unnamed' for empty inputs.
-
-    Source: https://github.com/django/django/blob/main/django/utils/text.py#L453
-    """
-    value = "" if value is None else str(value)
-    if not value:
-        return "unnamed"
-
-    if allow_unicode:
-        value = unicodedata.normalize("NFKC", value)
-    else:
-        value = (
-            unicodedata.normalize("NFKD", value)
-            .encode("ascii", "ignore")
-            .decode("ascii")
-        )
-
-    value = value.lower()
-    # keep alphanumerics, underscores, spaces and hyphens
-    value = re.sub(r"[^\w\s-]", "", value)
-    value = re.sub(r"[-\s]+", "-", value).strip("-_ ")
-    return value or "unnamed"

--- a/f/common_logic/identifier_utils.py
+++ b/f/common_logic/identifier_utils.py
@@ -229,3 +229,32 @@ def normalize_and_snakecase_keys(dictionary, special_case_keys=None):
 
         new_dict[final_key] = value
     return new_dict
+
+
+def slugify(value, allow_unicode: bool = False) -> str:
+    """A safe slugify utility.
+
+    - Converts to str, normalizes unicode, optionally keeps unicode.
+    - Returns an ASCII-ish slug of the input suitable for file names.
+    - Returns 'unnamed' for empty inputs.
+
+    Source: https://github.com/django/django/blob/main/django/utils/text.py#L453
+    """
+    value = "" if value is None else str(value)
+    if not value:
+        return "unnamed"
+
+    if allow_unicode:
+        value = unicodedata.normalize("NFKC", value)
+    else:
+        value = (
+            unicodedata.normalize("NFKD", value)
+            .encode("ascii", "ignore")
+            .decode("ascii")
+        )
+
+    value = value.lower()
+    # keep alphanumerics, underscores, spaces and hyphens
+    value = re.sub(r"[^\w\s-]", "", value)
+    value = re.sub(r"[-\s]+", "-", value).strip("-_ ")
+    return value or "unnamed"

--- a/f/common_logic/tests/data_conversion_test.py
+++ b/f/common_logic/tests/data_conversion_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from f.common_logic.data_conversion import convert_data, slugify
+from f.common_logic.data_conversion import convert_data
 
 
 def _validate_geojson_structure(result, expected_feature_count):
@@ -1050,11 +1050,3 @@ def test_convert_data__smart_patrol_xml(smart_patrol_sample_xml_file):
     assert logging_obs is not None
     assert logging_obs["properties"]["severity"] == "medium"
     assert logging_obs["properties"]["trees_cut"] == 5.0
-
-
-def test_slugify_empty_and_unicode():
-    assert slugify(None) == "unnamed"
-    assert slugify("") == "unnamed"
-    assert slugify("Hello World!") == "hello-world"
-    assert slugify("Café", allow_unicode=False) == "cafe"
-

--- a/f/common_logic/tests/identifier_utils_test.py
+++ b/f/common_logic/tests/identifier_utils_test.py
@@ -3,6 +3,7 @@ from f.common_logic.identifier_utils import (
     normalize_and_snakecase_keys,
     normalize_identifier,
     sanitize_sql_message,
+    slugify,
 )
 
 
@@ -310,3 +311,10 @@ def test_normalize_identifier_edge_cases():
     # Maxlen with ensure_leading_alpha
     assert normalize_identifier("123", maxlen=2, ensure_leading_alpha=True) == "_1"
     assert normalize_identifier("123", maxlen=1, ensure_leading_alpha=True) == "_"
+
+
+def test_slugify_empty_and_unicode():
+    assert slugify(None) == "unnamed"
+    assert slugify("") == "unnamed"
+    assert slugify("Hello World!") == "hello-world"
+    assert slugify("Café", allow_unicode=False) == "cafe"

--- a/f/connectors/arcgis/arcgis_download_feature_layer_anonymously.py
+++ b/f/connectors/arcgis/arcgis_download_feature_layer_anonymously.py
@@ -20,8 +20,8 @@ from pyproj import Transformer
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from f.common_logic.data_conversion import slugify
 from f.common_logic.file_operations import save_data_to_file
+from f.common_logic.identifier_utils import slugify
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Goal

A change that should have no overall impact, but just makes for better organization -- `slugify()` is hereby moved to `identifier_utils` module from `data_conversion` module.