### PR TITLE
fix: remove darkMode = true for the apps

### DIFF
--- a/f/apps/gc_dataset_importer.app/app.yaml
+++ b/f/apps/gc_dataset_importer.app/app.yaml
@@ -41,7 +41,6 @@ value:
       text:
         class: ''
         style: ''
-  darkMode: true
   fullscreen: false
   grid:
     - '12':

--- a/f/apps/local_contexts.app/app.yaml
+++ b/f/apps/local_contexts.app/app.yaml
@@ -41,7 +41,6 @@ value:
       text:
         class: ''
         style: ''
-  darkMode: true
   fullscreen: false
   grid:
     - '12':


### PR DESCRIPTION
## Goal

By removing `darkMode: true` the Dataset Uploader and Local Contexts app themes fall back to detecting the browser theme preference.