### PR TITLE
CoMapeo script returns per-project stats

### DIFF
--- a/f/connectors/comapeo/comapeo_pull.py
+++ b/f/connectors/comapeo/comapeo_pull.py
@@ -123,7 +123,7 @@ def main(
         # even when we fail the run due to missing attachments.
         error_msg_with_report = (
             f"{error_msg}\n"
-            f"per_project_stats={json.dumps(per_project_stats, ensure_ascii=False, sort_keys=True)}"
+            f"per_project_stats={json.dumps(per_project_stats, ensure_ascii=False)}"
         )
         raise CoMapeoPullError(
             error_msg_with_report,

--- a/f/connectors/comapeo/comapeo_pull.py
+++ b/f/connectors/comapeo/comapeo_pull.py
@@ -29,6 +29,17 @@ class comapeo_server(TypedDict):
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+class CoMapeoPullError(RuntimeError):
+    """Raised when the run produces partial output plus an error.
+
+    The per-project report is always available on `.per_project_stats`, so callers
+    (and Windmill logs) can still access the full metrics even when the run fails.
+    """
+
+    def __init__(self, message: str, *, per_project_stats: dict):
+        super().__init__(message)
+        self.per_project_stats = per_project_stats
+
 
 def main(
     comapeo: comapeo_server,
@@ -52,11 +63,11 @@ def main(
         logger.info(
             "No projects fetched. Skipping data processing and database writing."
         )
-        return
+        return {}
 
     logger.info(f"Fetched {len(comapeo_projects)} projects.")
 
-    comapeo_projects_geojson, stats, total_failed_observations_count = (
+    comapeo_projects_geojson, stats, total_failed_observations_count, per_project_stats = (
         download_and_transform_comapeo_data(
             server_url,
             session,
@@ -108,7 +119,18 @@ def main(
             f"{total_failed_observations_count} observation(s) affected. "
             f"See *_missing_attachments.geojson files for details."
         )
-        raise RuntimeError(error_msg)
+        # Include the full report in the exception so callers still get metrics
+        # even when we fail the run due to missing attachments.
+        error_msg_with_report = (
+            f"{error_msg}\n"
+            f"per_project_stats={json.dumps(per_project_stats, ensure_ascii=False, sort_keys=True)}"
+        )
+        raise CoMapeoPullError(
+            error_msg_with_report,
+            per_project_stats=per_project_stats,
+        )
+
+    return per_project_stats
 
 
 def fetch_comapeo_projects(server_url, session, comapeo_project_blocklist):
@@ -342,6 +364,7 @@ def download_project_observations(server_url, session, project_id, project_dir):
 
             for attachment in observation["attachments"]:
                 if "url" in attachment:
+                    stats["attachment_attempted"] += 1
                     file_name, skipped, failed = download_file(
                         attachment["url"],
                         session,
@@ -968,6 +991,7 @@ def download_and_transform_comapeo_data(
     comapeo_data = {}
     stats = Counter()
     total_failed_observations_count = 0
+    per_project_stats = {}
 
     for index, project in enumerate(comapeo_projects):
         project_id = project["project_id"]
@@ -1050,6 +1074,11 @@ def download_and_transform_comapeo_data(
         }
 
         # Aggregate statistics
+        per_project_stats[sanitized_project_name] = {
+            "observations_fetched": len(observations),
+            "attachments_failed": attachment_stats["attachment_failed"],
+        }
+
         stats["skipped_attachments"] += attachment_stats["skipped_attachments"]
         stats["attachment_failed"] += attachment_stats["attachment_failed"]
         stats["skipped_icons"] += icon_stats["skipped_icons"]
@@ -1069,4 +1098,4 @@ def download_and_transform_comapeo_data(
         logger.info(
             f"Project {index + 1} (ID: {project_id}, name: {project_name}): Processed {len(observations)} observation(s) and {len(tracks)} track(s)."
         )
-    return comapeo_data, stats, total_failed_observations_count
+    return comapeo_data, stats, total_failed_observations_count, per_project_stats

--- a/f/connectors/comapeo/tests/comapeo_pull_test.py
+++ b/f/connectors/comapeo/tests/comapeo_pull_test.py
@@ -416,6 +416,7 @@ def test_download_project_observations_with_failures(mocked_responses, tmp_path)
     )
 
     assert len(observations) == 2
+    assert stats["attachment_attempted"] == 3
     assert stats["attachment_failed"] == 2  # Two attachments failed
     assert stats["skipped_attachments"] == 0
 
@@ -484,6 +485,7 @@ def test_download_project_observations_with_skipped(mocked_responses, tmp_path):
     )
 
     assert len(observations) == 1
+    assert stats["attachment_attempted"] == 1
     assert stats["skipped_attachments"] == 1  # Attachment was skipped (already exists)
     assert stats["attachment_failed"] == 0
     assert len(failed_observations_info) == 0  # No failures
@@ -787,13 +789,20 @@ def test_download_file(mocked_responses, tmp_path):
 def test_script_e2e(comapeoserver_observations, pg_database, tmp_path):
     asset_storage = tmp_path / "datalake"
 
-    main(
+    run_metrics = main(
         comapeoserver_observations.comapeo_server,
         comapeoserver_observations.comapeo_project_blocklist,
         pg_database,
         "comapeo",
         asset_storage,
     )
+
+    assert run_metrics == {
+        "forest_expedition": {
+            "observations_fetched": 3,
+            "attachments_failed": 0,
+        }
+    }
 
     # Attachments are saved to disk
     assert (
@@ -1037,6 +1046,8 @@ def test_missing_attachments_geojson_created(
         assert "1 attachment(s) failed to download" in error_msg
         assert "1 observation(s) affected" in error_msg
         assert "missing_attachments.geojson" in error_msg
+        assert "per_project_stats=" in error_msg
+        assert '"attachments_failed": 1' in error_msg
 
     # Check that the missing attachments GeoJSON file was created despite the error
     missing_attachments_path = (
@@ -1073,13 +1084,20 @@ def test_no_missing_attachments_geojson_when_all_succeed(
     asset_storage = tmp_path / "datalake"
 
     # Run the main script (all attachments should succeed based on fixture mocks)
-    main(
+    run_metrics = main(
         comapeoserver_observations.comapeo_server,
         comapeoserver_observations.comapeo_project_blocklist,
         pg_database,
         "comapeo",
         asset_storage,
     )
+
+    assert run_metrics == {
+        "forest_expedition": {
+            "observations_fetched": 3,
+            "attachments_failed": 0,
+        }
+    }
 
     # Check that no missing attachments GeoJSON file was created
     missing_attachments_path = (


### PR DESCRIPTION
## Goal

Closes #231.

## Screenshots

Runtime log:

```
CoMapeoPullError: 335 attachment(s) failed to download. 171 observation(s) affected. See *_missing_attachments.geojson files for details.
 File "/tmp/windmill/wk-default-baf9a2830a0b-XlGUY/019dbd29-5286-83ce-791f-f5271c227f9e/f/connectors/comapeo/comapeo_pull.py", line 128, in main
    raise CoMapeoPullError(
{
    "per_project_stats": {
        "x_project": {
            "observations_fetched": 325,
            "attachments_failed": 138,
        },
        "y_project": {
            "observations_fetched": 373,
            "attachments_failed": 0,
        },
        "z_1": {
            "observations_fetched": 1179,
            "attachments_failed": 197,
        }
    }
}
```

## What I changed and why

Added a `CoMapeoPullError` class that tracks the two things people want to know about a CoMapeo project:

1. How many observations were fetched?
2. How many attachments failed to download?

## What I'm not doing here

Worrying about DB writes, or existing attachments.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None