### PR TITLE
Support CyberTracker uploads in GC Dataset Uploader

### DIFF
--- a/f/apps/gc_dataset_importer.app/2_upload_and_convert_file.inline_script.lock
+++ b/f/apps/gc_dataset_importer.app/2_upload_and_convert_file.inline_script.lock
@@ -1,13 +1,13 @@
 # py: 3.13
 attrs==26.1.0
-certifi==2026.2.25
-click==8.3.2
+certifi==2026.4.22
+click==8.3.3
 click-plugins==1.1.1.2
 cligj==0.7.2
 et-xmlfile==2.0.0
 filetype==1.2.0
 fiona==1.10.1
-lxml==6.0.2
+lxml==6.1.0
 numpy==2.4.4
 openpyxl==3.1.5
 pandas==3.0.2

--- a/f/apps/gc_dataset_importer.app/2_upload_and_convert_file.inline_script.py
+++ b/f/apps/gc_dataset_importer.app/2_upload_and_convert_file.inline_script.py
@@ -167,6 +167,7 @@ def main(uploaded_file, dataset_name, table_exists, table_name, db: postgresql):
             None,
             output_filename,
             output_format,
+            file_format,
             new_rows,
             updates,
             new_columns,
@@ -176,4 +177,4 @@ def main(uploaded_file, dataset_name, table_exists, table_name, db: postgresql):
     except Exception as e:
         error_msg = f"Error during file upload and conversion: {e}"
         logger.error(error_msg)
-        return False, error_msg, None, None, None, None, None, None
+        return False, error_msg, None, None, None, None, None, None, None

--- a/f/apps/gc_dataset_importer.app/4_apply_transformation_and_write_to_database.inline_script.lock
+++ b/f/apps/gc_dataset_importer.app/4_apply_transformation_and_write_to_database.inline_script.lock
@@ -1,16 +1,16 @@
 # py: 3.13
 annotated-types==0.7.0
 attrs==26.1.0
-certifi==2026.2.25
+certifi==2026.4.22
 charset-normalizer==3.4.7
-click==8.3.2
+click==8.3.3
 click-plugins==1.1.1.2
 cligj==0.7.2
 et-xmlfile==2.0.0
 filetype==1.2.0
 fiona==1.10.1
-idna==3.11
-lxml==6.0.2
+idna==3.13
+lxml==6.1.0
 numpy==2.4.4
 openpyxl==3.1.5
 pandas==3.0.2

--- a/f/apps/gc_dataset_importer.app/4_apply_transformation_and_write_to_database.inline_script.py
+++ b/f/apps/gc_dataset_importer.app/4_apply_transformation_and_write_to_database.inline_script.py
@@ -11,6 +11,9 @@ from f.common_logic.file_operations import (
     save_uploaded_file_to_temp,
 )
 from f.connectors.csv.csv_to_postgres import main as save_csv_to_postgres
+from f.connectors.cybertracker.cybertracker_observations_from_backup import (
+    transform_cybertracker_data,
+)
 from f.connectors.geojson.geojson_to_postgres import main as save_geojson_to_postgres
 from f.connectors.kobotoolbox.kobotoolbox_responses import (
     transform_kobotoolbox_form_data,
@@ -132,7 +135,7 @@ def main(
             # Must be absolute path under tmp_dir so csv_path + attachment_root resolve correctly
             file_path = uploaded_path
             logger.info(f"Using parsed file: {file_path}")
-            
+
         # Save to PostgreSQL
         file_path_obj = Path(file_path)
         if final_output_format == "geojson":
@@ -349,6 +352,10 @@ def _apply_transformation(data, data_source, dataset_name, output_format):
         ("geojson", "SMART"): (
             transform_smart_patrol_data,
             "SMART transformation applied",
+        ),
+        ("geojson", "CyberTracker"): (
+            transform_cybertracker_data,
+            "CyberTracker transformation applied",
         ),
     }
 

--- a/f/apps/gc_dataset_importer.app/app.yaml
+++ b/f/apps/gc_dataset_importer.app/app.yaml
@@ -586,8 +586,8 @@ value:
             connections: []
             eval: >-
               <p class="text-xs text-center"><strong>Accepted formats:</strong>
-              CSV, GeoJSON, GPX, GeoPackage, JSON, KML, Shapefile, XLS, XLSX,
-              XML (<em>SMART only</em>)<br>
+              CSV, GeoJSON, GPX, GeoPackage, JSON (i.e. for CyberTracker), KML,
+              Shapefile, XLS, XLSX, XML (<em>SMART only</em>)<br>
 
               <strong>Note:</strong> To upload media attachments (like photos),
               please use Filebrowser. See <a
@@ -768,39 +768,48 @@ value:
                     - table_name
                     - db
             transformer:
-              content: |-
+              content: |+
                 state.uploadSuccess = result[0];
                 state.uploadErrorMessage = result[1];
                 state.fileNameOriginal = selectFile.result[0].name;
                 state.fileNameParsed = result[2];
                 state.outputFormat = result[3];
-                state.newRows = result[4];
-                state.updatedRows = result[5];
-                state.newColumns = result[6];
-                state.columnNames= result[7];
+                state.fileFormat = result[4];
+                if (result[4] === "cybertracker") {
+                  state.dataSource = "CyberTracker"
+                }
+                state.newRows = result[5];
+                state.updatedRows = result[6];
+                state.newColumns = result[7];
+                state.columnNames= result[8];
+
               language: frontend
               path: f/apps/gc_dataset_importer/Transformer
               suggestedRefreshOn:
                 - id: state
-                  key: outputFormat
-                - id: state
-                  key: newColumns
-                - id: state
-                  key: columnNames
-                - id: state
                   key: newRows
                 - id: state
-                  key: updatedRows
-                - id: state
-                  key: uploadSuccess
-                - id: state
-                  key: fileNameOriginal
+                  key: fileNameParsed
                 - id: state
                   key: uploadErrorMessage
+                - id: state
+                  key: outputFormat
                 - id: selectFile
                   key: result
                 - id: state
-                  key: fileNameParsed
+                  key: updatedRows
+                - id: state
+                  key: fileFormat
+                - id: state
+                  key: columnNames
+                - id: state
+                  key: fileNameOriginal
+                - id: state
+                  key: dataSource
+                - id: state
+                  key: newColumns
+                - id: state
+                  key: uploadSuccess
           configuration:
             afterIcon:
               type: static
@@ -1064,7 +1073,11 @@ value:
               type: static
               value: false
             defaultValue:
-              type: static
+              type: evalv2
+              connections:
+                - id: dataSource
+                  componentId: state
+              expr: state.dataSource
             disabled:
               type: evalv2
               value: false
@@ -1080,6 +1093,8 @@ value:
               value:
                 - value: CoMapeo
                   label: CoMapeo
+                - value: CyberTracker
+                  label: CyberTracker
                 - value: KoboToolbox
                   label: KoboToolbox
                 - value: Mapeo

--- a/f/common_logic/data_conversion.py
+++ b/f/common_logic/data_conversion.py
@@ -871,7 +871,7 @@ def read_cybertracker(path: Path):
     dict
         GeoJSON FeatureCollection with observation features.
     """
-    # Lazy import to avoid forcing CyberTracker dependencies on all users of data_conversion.py
+    # Lazy import to avoid forcing this script dependencies on all users of data_conversion.py
     from f.connectors.cybertracker.cybertracker_observations_from_backup import (
         parse_cybertracker_json,
     )

--- a/f/common_logic/data_conversion.py
+++ b/f/common_logic/data_conversion.py
@@ -25,6 +25,25 @@ import pandas as pd
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# CyberTracker mobile backup export: top-level JSON array of session objects.
+_CYBERTRACKER_SESSION_KEYS = frozenset(
+    {"sessionId", "schemaHash", "records", "deviceId", "db"}
+)
+
+
+def _is_cybertracker_backup_json(data: object) -> bool:
+    """True if ``data`` matches CyberTracker ``data/0.json`` session-export shape."""
+    if not isinstance(data, list) or not data:
+        return False
+    first = data[0]
+    if not isinstance(first, dict):
+        return False
+    if not _CYBERTRACKER_SESSION_KEYS.issubset(first.keys()):
+        return False
+    return isinstance(first.get("records"), list) and isinstance(
+        first.get("db"), dict
+    )
+
 
 def detect_structured_data_type(file_paths: list[str]) -> str:
     """
@@ -35,7 +54,7 @@ def detect_structured_data_type(file_paths: list[str]) -> str:
     tabular data pipelines. It supports:
     - Spatial formats: geojson, kml, gpx, shapefile, geopackage
     - Tabular formats: csv, xls, xlsx
-    - General structured formats: json
+    - General structured formats: json, cybertracker (CyberTracker session backup JSON)
 
     Accepts a list of file paths (as i.e. returned by save_uploaded_file_to_temp) to
     support multi-file formats like ESRI shapefiles. For single-file
@@ -78,7 +97,7 @@ def detect_structured_data_type(file_paths: list[str]) -> str:
         return detected_type
 
     def _detect_json_subtype(path: Path) -> str:
-        """Distinguish between JSON and GeoJSON using extension and content sniffing."""
+        """Distinguish between JSON, GeoJSON, and CyberTracker JSON using extension and content sniffing."""
         if path.suffix.lower() == ".geojson":
             logger.info(f"File {path.name} detected as geojson (by extension)")
             return "geojson"
@@ -92,6 +111,12 @@ def detect_structured_data_type(file_paths: list[str]) -> str:
                 if isinstance(data, dict) and data.get("type") == "FeatureCollection":
                     logger.info(f"File {path.name} detected as geojson (by content)")
                     return "geojson"
+
+                if _is_cybertracker_backup_json(data):
+                    logger.info(
+                        f"File {path.name} detected as cybertracker JSON (by content)"
+                    )
+                    return "cybertracker"
             except (json.JSONDecodeError, UnicodeDecodeError, OSError):
                 # If we can't parse it, fall back to json
                 pass
@@ -245,7 +270,8 @@ def convert_data(
 
     When output_format is None (default), the implicit mapping is used:
     - Tabular inputs (csv, xlsx, xls, json) → 'csv'
-    - Spatial inputs (gpx, kml, geojson, smart, shapefile) → 'geojson'
+    - Spatial inputs (gpx, kml, geojson, smart, cybertracker, shapefile,
+      geopackage) → 'geojson'
 
     When output_format is explicitly set, cross-format conversion is attempted.
     Currently supported: tabular → 'geojson' (requires latitude_col and longitude_col).
@@ -261,7 +287,7 @@ def convert_data(
         For multi-file formats (shapefile), the .shp is located automatically.
     file_format : str
         Validated file format: one of 'csv', 'xlsx', 'xls', 'json',
-        'gpx', 'kml', 'geojson', 'smart', 'shapefile', 'geopackage'.
+        'gpx', 'kml', 'geojson', 'cybertracker', 'smart', 'shapefile', 'geopackage'.
     output_format : str, optional
         Desired output format ('csv' or 'geojson'). When None, inferred from
         file_format.
@@ -301,6 +327,8 @@ def convert_data(
             data, default_output = read_gpx(path), "geojson"
         case "kml":
             data, default_output = read_kml(path), "geojson"
+        case "cybertracker":
+            data, default_output = read_cybertracker(path), "geojson"
         case "smart":
             data, default_output = read_smart_xml(path), "geojson"
         case "shapefile":
@@ -826,6 +854,29 @@ def read_kml(path: Path):
         raise ValueError("No valid features found in input file")
 
     return {"type": "FeatureCollection", "features": features}
+
+
+@handle_file_errors
+def read_cybertracker(path: Path):
+    """
+    Reads a CyberTracker JSON file and returns a GeoJSON FeatureCollection.
+
+    Parameters
+    ----------
+    path : Path
+        Path to the CyberTracker JSON file.
+
+    Returns
+    -------
+    dict
+        GeoJSON FeatureCollection with observation features.
+    """
+    # Lazy import to avoid forcing CyberTracker dependencies on all users of data_conversion.py
+    from f.connectors.cybertracker.cybertracker_observations_from_backup import (
+        parse_cybertracker_json,
+    )
+
+    return parse_cybertracker_json(path)
 
 
 @handle_file_errors

--- a/f/common_logic/tests/data_conversion_test.py
+++ b/f/common_logic/tests/data_conversion_test.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 
@@ -7,6 +8,11 @@ from f.common_logic.data_conversion import (
     detect_structured_data_type,
     read_geopackage,
     to_geojson,
+)
+
+_CYBERTRACKER_FIXTURE = (
+    Path(__file__).resolve().parent.parent.parent
+    / "connectors/cybertracker/tests/assets/0.json"
 )
 
 
@@ -1181,6 +1187,23 @@ def test_convert_data__geojson_with_utf8_bom(tmp_path):
     assert output_format == "geojson"
     _validate_geojson_structure(result, 1)
     assert result["features"][0]["properties"]["name"] == "bom_point"
+
+
+def test_convert_data__cybertracker_json_fixture():
+    assert _CYBERTRACKER_FIXTURE.is_file()
+    assert detect_structured_data_type([str(_CYBERTRACKER_FIXTURE)]) == "cybertracker"
+
+    result, output_format = convert_data(
+        [str(_CYBERTRACKER_FIXTURE)], "cybertracker"
+    )
+    assert output_format == "geojson"
+    _validate_geojson_structure(result, 3)
+
+    by_id = {f["id"]: f for f in result["features"]}
+    howler_wp = by_id["cb5e04cf13124dca9f1f1665ef059642"]
+    assert howler_wp["geometry"]["type"] == "Point"
+    assert howler_wp["geometry"]["coordinates"][0] == -77.0
+    assert howler_wp["geometry"]["coordinates"][1] == 38.0
 
 
 # --- Integrated tests ---

--- a/f/common_logic/tests/data_format_detection_test.py
+++ b/f/common_logic/tests/data_format_detection_test.py
@@ -4,6 +4,11 @@ import pandas as pd
 
 from f.common_logic.data_conversion import detect_structured_data_type
 
+_CYBERTRACKER_FIXTURE = (
+    Path(__file__).resolve().parent.parent.parent
+    / "connectors/cybertracker/tests/assets/0.json"
+)
+
 
 def test_structured_data_type__gpx_format(tmp_path: Path):
     file_path = tmp_path / "test.gpx"
@@ -70,6 +75,18 @@ def test_structured_data_type__regular_json_with_json_extension(tmp_path: Path):
     file_path = tmp_path / "regular.json"
     file_path.write_text('{"name": "John", "age": 30, "city": "New York"}')
     assert detect_structured_data_type([str(file_path)]) == "json"
+
+
+def test_structured_data_type__cybertracker_json_fixture():
+    assert _CYBERTRACKER_FIXTURE.is_file()
+    assert detect_structured_data_type([str(_CYBERTRACKER_FIXTURE)]) == "cybertracker"
+
+
+def test_structured_data_type__json_array_not_cybertracker(tmp_path: Path):
+    """Generic JSON arrays must not be classified as CyberTracker exports."""
+    path = tmp_path / "rows.json"
+    path.write_text('[{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]')
+    assert detect_structured_data_type([str(path)]) == "json"
 
 
 def test_structured_data_type__excel_format(tmp_path: Path):


### PR DESCRIPTION
## Goal

Stacked onto https://github.com/ConservationMetrics/gc-scripts-hub/pull/235; closes #233 once both merged.

## ~Screenshots~ How I know this works

I tried it in runtime with several CyberTracker backups.

## What I changed and why

* Most of the work happens in the data detection and conversion code. The patterns here are similar to what we did for SMART.
  * `detect_structured_data_type()` does an additional check for JSON to sniff if it is a CyberTracker file, based on a set of known keys that appear in every session / observation. 
    * On the one hand, I don't love the approach used here as the CyberTracker keys are not super deterministic. Like, to compare with what we do SMART, checking for a set of keys like `schemaHash`, `records`, and `db` is not the same as sniffing for an explicit declaration of a SMART XML namespace). 
    * On the other hand, I can't imagine any of our users coming to Guardian Connector with a wild JSON file with this specific set of keys that isn't from CyberTracker. (To be honest, I don't imagine many users trying to upload a JSON file that isn't GeoJSON at all.) 
    * So I find this to be an acceptable solution. The app will fail loudly if something goes wrong in the conversion, anyway, so we at least don't risk writing non-CyberTracker data to the warehouse.
  * `convert_data()` now accepts `cybertracker` file format; `read_cybertracker()` calls `parse_cybertracker_json()` added by #235.
* The app already accepted JSON files, so the detection / conversion changes will handle the conversion to GeoJSON. The only additional thing that happens in the app is that we auto-set "CyberTracker" as data source, as we will already know this from importing. And call `transform_cybertracker_data` to add the `data_source` col.

## What I'm not doing here

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None