### PR TITLE
Implement Python dependency cooldown (7 days) in CI/test install flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,10 @@ jobs:
       - run:
           name: Install tox for Python 3.11
           command: |
-            python -m pip install --upgrade pip
+            python -m pip install --upgrade "pip>=26.1"
             pip install tox~=4.18 tox-docker~=5.0
       - run:
           name: Run tests
           command: tox -- -v
+          environment:
+            PIP_UPLOADED_PRIOR_TO: P7D

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,11 @@ Merging branches and PRs to `main`:
 
 # Tests
 
+## Dependency cooldown policy (Python)
+
+New Python package versions must be at least 7 days old before they can be introduced.
+If dependency resolution fails due to package age, wait and retry, or use an older version.
+
 ## Testing Strategy
 
 Keep the test suite


### PR DESCRIPTION
## Goal

Implement a 7-day Python dependency cooldown in CI to reduce supply-chain exposure from newly uploaded package versions. Closes #237 

## Screenshots

N/A (CI/security hardening change)

## What I changed and why

I updated CircleCI to install `pip>=26.1` and set `PIP_UPLOADED_PRIOR_TO: P7D` in line with [the docs](https://pip.pypa.io/en/latest/cli/pip_install/#cmdoption-uploaded-prior-to) when running tox. This applies pip’s native upload-time gate so dependency resolution rejects packages newer than 7 days, aligning with the cooldown policy while staying inside standard pip behavior.

I also added a brief policy note to `CONTRIBUTING.md` so contributors understand age-gate failures and the expected response (wait or use an older version). 

## What I'm not doing here

- No changes to individual script lockfiles in this PR.
- No private index/proxy rollout.
- No broad dependency upgrades unrelated to cooldown.

## LLM use disclosure
None