### PR TITLE
Drop unused `dataset_name` param from SMART/CyberTracker transforms

### DIFF
--- a/f/apps/gc_dataset_importer.app/4_apply_transformation_and_write_to_database.inline_script.py
+++ b/f/apps/gc_dataset_importer.app/4_apply_transformation_and_write_to_database.inline_script.py
@@ -345,10 +345,13 @@ def _apply_transformation(data, data_source, dataset_name, output_format):
         #     "Comapeo transformation applied",
         # ),
         ("csv", "KoboToolbox"): (
-            transform_kobotoolbox_form_data,
+            lambda d: transform_kobotoolbox_form_data(d, dataset_name),
             "Kobotoolbox transformation applied",
         ),
-        ("csv", "ODK"): (transform_odk_form_data, "ODK transformation applied"),
+        ("csv", "ODK"): (
+            lambda d: transform_odk_form_data(d, dataset_name),
+            "ODK transformation applied",
+        ),
         ("geojson", "SMART"): (
             transform_smart_patrol_data,
             "SMART transformation applied",
@@ -360,9 +363,10 @@ def _apply_transformation(data, data_source, dataset_name, output_format):
     }
 
     transform_key = (output_format, data_source)
+
     if transform_key in transformations:
         transform_func, log_msg = transformations[transform_key]
-        transformed_data = transform_func(data, dataset_name)
+        transformed_data = transform_func(data)
         logger.info(log_msg)
         return transformed_data, True
     elif data_source:  # Apply generic data_source transformation if data_source is set

--- a/f/connectors/cybertracker/cybertracker_observations_from_backup.py
+++ b/f/connectors/cybertracker/cybertracker_observations_from_backup.py
@@ -98,7 +98,7 @@ def main(
         logger.warning("No observations found in CyberTracker JSON")
 
 
-def transform_cybertracker_data(data: dict, dataset_name: str = None) -> dict:
+def transform_cybertracker_data(data: dict) -> dict:
     """
     Apply CT-specific transformations to observations data.
 
@@ -109,9 +109,6 @@ def transform_cybertracker_data(data: dict, dataset_name: str = None) -> dict:
     ----------
     data : dict
         GeoJSON FeatureCollection with CT observations.
-    dataset_name : str, optional
-        Human-readable name of the dataset (currently unused, included for
-        consistency with other transformation functions).
 
     Returns
     -------

--- a/f/connectors/smart/smart_patrols.py
+++ b/f/connectors/smart/smart_patrols.py
@@ -90,7 +90,7 @@ def main(
         logger.warning("No observations found in SMART patrol XML")
 
 
-def transform_smart_patrol_data(data: dict, dataset_name: str = None) -> dict:
+def transform_smart_patrol_data(data: dict) -> dict:
     """
     Apply SMART-specific transformations to patrol data.
 
@@ -101,9 +101,6 @@ def transform_smart_patrol_data(data: dict, dataset_name: str = None) -> dict:
     ----------
     data : dict
         GeoJSON FeatureCollection with SMART patrol observations.
-    dataset_name : str, optional
-        Human-readable name of the dataset (currently unused, included for
-        consistency with other transformation functions).
 
     Returns
     -------


### PR DESCRIPTION
## Goal

`transform_smart_patrol_data` and `transform_cybertracker_data` accepted a dead weight `dataset_name` arg they never used. This PR removes it and updates the dispatcher in `_apply_transformation` to bind `dataset_name` via lambdas only for the Kobo/ODK transforms that can actually use it as `form_name`.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None