### PR TITLE
Fix CI: work around tox-docker Gateway KeyError on newer Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,3 +50,7 @@ jobs:
           command: tox -- -v
           environment:
             PIP_UPLOADED_PRIOR_TO: P7D
+            # Skip tox-docker's NetworkSettings.Gateway lookup (broken on newer
+            # Docker in ubuntu-2404:current). machine-executor reaches containers
+            # via localhost anyway.
+            TOX_DOCKER_GATEWAY: localhost

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,5 +52,6 @@ jobs:
             PIP_UPLOADED_PRIOR_TO: P7D
             # Skip tox-docker's NetworkSettings.Gateway lookup (broken on newer
             # Docker in ubuntu-2404:current). machine-executor reaches containers
-            # via localhost anyway.
+            # via localhost anyway. Workaround until https://github.com/tox-dev/tox-docker/pull/196
+            # is merged and released.
             TOX_DOCKER_GATEWAY: localhost

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ environment =
     PORT=10010
 expose =
     TOX_DOCKER_GCS_PORT=10010/tcp
+network_mode = bridge
 
 [testenv:arcgis]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ environment =
     PORT=10010
 expose =
     TOX_DOCKER_GCS_PORT=10010/tcp
-network_mode = bridge
 
 [testenv:arcgis]
 deps =


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-scripts-hub/issues/242. Unblock `alerts` tox env on CI. 

This was not a Python / pip version issue as initially suspected, but rather a discrepancy between `tox-docker` and `ubuntu-2404:current`.

## What I changed and why

We set `TOX_DOCKER_GATEWAY: localhost` in `.circleci/config.yml`. 

Newer Docker on `ubuntu-2404:current` no longer fills top-level `NetworkSettings.Gateway`, so tox-docker seems to crash with a KeyError. Claude Opus 4.7 did this diagnosis:

> tox-docker has a documented escape hatch for exactly this: if `TOX_DOCKER_GATEWAY` is set, it skips `container.attrs["NetworkSettings"]["Gateway"]` and uses `socket.gethostbyname(gateway)` instead. Setting it to localhost resolves to 127.0.0.1, which is what you want on `machine-executor` anyway (host networking).

## How I convinced myself this is right

- Trace lands in tox-docker, not our code; `pip freeze` is identical to previous green runs on CircleCI.
- `alerts` tests seems to be passing again in CI.

## What I'm not doing here

- Pinning `ubuntu-2404` to a dated tag.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Claude Opus 4.7 helped diagnose.