### PR TITLE
Flatten KoboToolbox matrix and repeat-group responses instead of dumping them as JSON blobs

### DIFF
--- a/f/common_logic/file_operations.py
+++ b/f/common_logic/file_operations.py
@@ -71,6 +71,22 @@ def get_safe_file_path(storage_path: str, db_table_name: str, file_type: str):
     return file_path
 
 
+def _serialize_csv_cell(value):
+    """Serialize a Python value for a CSV cell.
+
+    Lists and dicts are JSON-encoded so they round-trip with how
+    ``StructuredDBWriter`` persists complex values to TEXT columns. ``None``
+    becomes an empty string (which downstream readers like
+    ``csv_to_postgres.transform_csv_data`` translate back to ``None``).
+    Other values are written as-is.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, (list, dict)):
+        return json.dumps(value)
+    return value
+
+
 def save_data_to_file(data, filename: str, storage_path: str, file_type: str = "json"):
     """
     Saves the provided data to a file in the specified format and storage path.
@@ -78,7 +94,9 @@ def save_data_to_file(data, filename: str, storage_path: str, file_type: str = "
     Parameters
     ----------
     data : list or dict
-        The data to be saved. For CSV, should be a list of rows including a header.
+        The data to be saved. For CSV, may be either a list of rows (each row a
+        list of cells, with the first row being the header) or a list of dicts
+        (header is the union of keys with ``_id`` first when present).
     filename : str
         The name of the file to save the data to, without extension.
     storage_path : str
@@ -103,8 +121,21 @@ def save_data_to_file(data, filename: str, storage_path: str, file_type: str = "
             json.dump(data, f)
     elif file_type == "csv":
         with file_path.open("w", newline="") as f:
-            writer = csv.writer(f, quoting=csv.QUOTE_NONNUMERIC)
-            writer.writerows(data)
+            if isinstance(data[0], dict):
+                other_keys = sorted({k for row in data for k in row if k != "_id"})
+                has_id = any("_id" in row for row in data)
+                fieldnames = (["_id"] + other_keys) if has_id else other_keys
+                writer = csv.DictWriter(
+                    f, fieldnames=fieldnames, quoting=csv.QUOTE_NONNUMERIC
+                )
+                writer.writeheader()
+                for row in data:
+                    writer.writerow(
+                        {k: _serialize_csv_cell(row.get(k)) for k in fieldnames}
+                    )
+            else:
+                writer = csv.writer(f, quoting=csv.QUOTE_NONNUMERIC)
+                writer.writerows(data)
     else:
         raise ValueError(f"Unsupported file type: {file_type}")
 

--- a/f/common_logic/tests/file_operations_test.py
+++ b/f/common_logic/tests/file_operations_test.py
@@ -47,6 +47,43 @@ def test_save_data_to_file__csv_empty(tmp_path: Path):
     assert not file_path.exists()
 
 
+def test_save_data_to_file__csv_list_of_dicts(tmp_path: Path):
+    """list[dict] CSV mode: _id first, sorted rest; lists/dicts JSON-encoded;
+    None becomes an empty cell (so csv_to_postgres can round-trip to NULL)."""
+    data = [
+        {
+            "_id": "a",
+            "name": "Alpha",
+            "tags": ["x", "y"],
+            "geo": {"type": "Point", "coordinates": [1, 2]},
+        },
+        {"_id": "b", "name": "Bravo"},
+    ]
+    save_data_to_file(data, "test", tmp_path, "csv")
+
+    rows = list(read_csv_to_list(tmp_path / "test.csv"))
+    assert [r["_id"] for r in rows] == ["a", "b"]
+    # _id first, remaining keys sorted alphabetically
+    assert list(rows[0].keys()) == ["_id", "geo", "name", "tags"]
+    # Complex values land as JSON strings
+    assert rows[0]["tags"] == '["x", "y"]'
+    assert rows[0]["geo"] == '{"type": "Point", "coordinates": [1, 2]}'
+    # Missing key in the second row is written as empty cell
+    assert rows[1]["tags"] == ""
+    assert rows[1]["geo"] == ""
+
+
+def test_save_data_to_file__csv_list_of_dicts_no_id(tmp_path: Path):
+    """When no row has an _id key, header is just the sorted union of keys."""
+    data = [{"name": "Alpha"}, {"name": "Bravo", "extra": "data"}]
+    save_data_to_file(data, "test", tmp_path, "csv")
+
+    rows = list(read_csv_to_list(tmp_path / "test.csv"))
+    assert list(rows[0].keys()) == ["extra", "name"]
+    assert rows[0]["extra"] == ""
+    assert rows[1]["extra"] == "data"
+
+
 def test_save_uploaded_file_to_temp__single_file(tmp_path: Path):
     input_path = tmp_path / "sample.csv"
     input_path.write_text("col1,col2\nval1,val2")

--- a/f/connectors/csv/csv_to_postgres.py
+++ b/f/connectors/csv/csv_to_postgres.py
@@ -18,6 +18,8 @@ def main(
     attachment_root: str = "/persistent-storage/datalake/",
     delete_csv_file: bool = False,
     id_column: str = None,
+    use_mapping_table: bool = False,
+    reverse_properties_separated_by: str | None = None,
 ):
     """
     Import CSV data into PostgreSQL table.
@@ -36,6 +38,15 @@ def main(
         Whether to delete the CSV file after processing.
     id_column : str, optional
         Name of column to use as primary key. If None, auto-generates _id.
+    use_mapping_table : bool
+        Forwarded to ``StructuredDBWriter``. Enables the ``__columns`` mapping
+        table for form-style data where original column names can exceed
+        Postgres' 63-char identifier limit. Defaults to False to preserve the
+        behavior of standalone CSV uploads.
+    reverse_properties_separated_by : str, optional
+        Forwarded to ``StructuredDBWriter``. When set (e.g. ``"/"``), nested
+        keys like ``meta/instanceID`` are reversed/rejoined into SQL-safe
+        column names. Defaults to None.
     """
     csv_path = Path(attachment_root) / Path(csv_path)
     transformed_csv_data = transform_csv_data(csv_path, id_column)
@@ -43,8 +54,8 @@ def main(
     db_writer = StructuredDBWriter(
         conninfo(db),
         db_table_name,
-        use_mapping_table=False,
-        reverse_properties_separated_by=None,
+        use_mapping_table=use_mapping_table,
+        reverse_properties_separated_by=reverse_properties_separated_by,
     )
     db_writer.handle_output(transformed_csv_data)
 
@@ -55,6 +66,12 @@ def main(
 def transform_csv_data(csv_path, id_column=None):
     """
     Transform CSV data into a list of dictionaries suitable for database insertion.
+
+    Empty string cells are converted to ``None`` so that missing values land in
+    the database as ``NULL`` rather than empty TEXT. This matches the typical
+    CSV convention of "empty cell = no value" and preserves round-trip
+    semantics when a CSV is produced via ``save_data_to_file`` (which writes
+    ``None`` as an empty cell).
 
     Parameters
     ----------
@@ -71,12 +88,12 @@ def transform_csv_data(csv_path, id_column=None):
     """
     with open(csv_path, "r", encoding="utf-8") as f:
         reader = csv.DictReader(f)
-        rows = list(reader)
+        rows = [{k: (v if v != "" else None) for k, v in row.items()} for row in reader]
 
     transformed_csv_data = []
     for idx, row in enumerate(rows, 1):
         # Use specified column as _id, or generate auto-incrementing _id
-        if id_column and id_column in row:
+        if id_column and id_column in row and row[id_column] is not None:
             row_id = row[id_column]
             # Remove the original id column since we're using it as _id
             if id_column != "_id":

--- a/f/connectors/csv/tests/csv_to_postgres_test.py
+++ b/f/connectors/csv/tests/csv_to_postgres_test.py
@@ -1,6 +1,6 @@
 import psycopg
 
-from f.connectors.csv.csv_to_postgres import main
+from f.connectors.csv.csv_to_postgres import main, transform_csv_data
 
 csv_fixture_path = "f/connectors/csv/tests/assets/"
 
@@ -90,3 +90,60 @@ def test_script_with_custom_id_column(pg_database):
                 "Selective logging area",
                 "Moderate depletion",
             )
+
+
+def test_transform_csv_data__empty_cells_become_none(tmp_path):
+    """Empty CSV cells round-trip to ``None`` so the DB can store NULL.
+
+    This matches typical CSV conventions and preserves NULL semantics when a
+    CSV produced by ``save_data_to_file`` (which writes ``None`` as an empty
+    cell) is read back in.
+    """
+    csv_file = tmp_path / "sparse.csv"
+    csv_file.write_text("_id,name,note\n1,Alpha,\n2,,Bravo note\n")
+
+    rows = transform_csv_data(csv_file, id_column="_id")
+    assert rows == [
+        {"_id": "1", "name": "Alpha", "note": None},
+        {"_id": "2", "name": None, "note": "Bravo note"},
+    ]
+
+
+def test_script_with_mapping_table_and_key_reversal(pg_database, tmp_path):
+    """Forwarding use_mapping_table/reverse_properties_separated_by to the
+    StructuredDBWriter enables form-style ingestion (used by ODK/Kobo/Epi)."""
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text(
+        '"_id","meta/instanceID","name"\n'
+        '"abc","uuid:111","Alpha"\n'
+        '"def","uuid:222","Bravo"\n'
+    )
+
+    main(
+        pg_database,
+        "form_responses",
+        "data.csv",
+        str(tmp_path),
+        False,
+        "_id",
+        use_mapping_table=True,
+        reverse_properties_separated_by="/",
+    )
+
+    with psycopg.connect(autocommit=True, **pg_database) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT COUNT(*) FROM form_responses")
+            assert cursor.fetchone()[0] == 2
+
+            # meta/instanceID got reversed to instanceID__meta
+            cursor.execute(
+                'SELECT "instanceID__meta" FROM form_responses WHERE _id = \'abc\''
+            )
+            assert cursor.fetchone() == ("uuid:111",)
+
+            # Mapping table is created and recorded
+            cursor.execute(
+                "SELECT sql_column FROM form_responses__columns "
+                "WHERE original_column = 'meta/instanceID'"
+            )
+            assert cursor.fetchone() == ("instanceID__meta",)

--- a/f/connectors/epicollect/epicollect_pull.py
+++ b/f/connectors/epicollect/epicollect_pull.py
@@ -9,8 +9,9 @@ from urllib.parse import parse_qs, urlparse
 
 import requests
 
-from f.common_logic.db_operations import StructuredDBWriter, conninfo, postgresql
+from f.common_logic.db_operations import postgresql
 from f.common_logic.file_operations import save_data_to_file
+from f.connectors.csv.csv_to_postgres import main as save_csv_to_postgres
 
 
 BASE_URL = "https://five.epicollect.net"
@@ -55,13 +56,24 @@ def main(
 
     transformed = transform_epicollect_entries(entries, form_name=form_name)
 
-    writer = StructuredDBWriter(
-        conninfo(db),
+    save_path = Path(attachment_root) / db_table_name
+    save_data_to_file(
+        transformed,
         db_table_name,
+        save_path,
+        file_type="csv",
+    )
+
+    save_csv_to_postgres(
+        db,
+        db_table_name,
+        str(Path(db_table_name) / f"{db_table_name}.csv"),
+        attachment_root,
+        delete_csv_file=False,
+        id_column="_id",
         use_mapping_table=True,
         reverse_properties_separated_by="/",
     )
-    writer.handle_output(transformed)
     logger.info(
         f"EpiCollect5 entries written to database table: [{db_table_name}]"
     )

--- a/f/connectors/epicollect/tests/epicollect_pull_test.py
+++ b/f/connectors/epicollect/tests/epicollect_pull_test.py
@@ -1,3 +1,5 @@
+import csv
+
 import psycopg
 
 from f.connectors.epicollect.epicollect_pull import (
@@ -34,6 +36,17 @@ def test_script_e2e(epicollect_server, pg_database, tmp_path):
     assert (attachments / PHOTO_FILENAME).exists()
     assert (attachments / AUDIO_FILENAME).exists()
     assert (attachments / VIDEO_FILENAME).exists()
+
+    # CSV artifact is also saved to disk, mirroring the GeoJSON-to-Postgres flow
+    csv_file = asset_storage / table_name / f"{table_name}.csv"
+    assert csv_file.exists()
+    with csv_file.open(newline="", encoding="utf-8") as f:
+        csv_rows = list(csv.DictReader(f))
+    assert len(csv_rows) == 3
+    assert {r["_id"] for r in csv_rows} >= {PRIMARY_UUID}
+    geo_row = next(r for r in csv_rows if r["_id"] == PRIMARY_UUID)
+    assert geo_row["g__coordinates"] == "[-74.072, 4.711]"
+    assert geo_row["dataset_name"] == FORM_NAME
 
     with psycopg.connect(autocommit=True, **pg_database) as conn:
         with conn.cursor() as cur:

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -55,6 +55,7 @@ def main(
         form_responses,
         form_name=form_name,
         form_languages=form_languages,
+        form_metadata=form_metadata,
     )
 
     save_path = Path(attachment_root) / db_table_name
@@ -342,7 +343,71 @@ def download_form_responses_and_attachments(
     return form_submissions, form_name, form_languages
 
 
-def transform_kobotoolbox_form_data(form_data, form_name=None, form_languages=None):
+def _leaf_key(slash_key: str) -> str:
+    return slash_key.rsplit("/", 1)[-1]
+
+
+def _is_kobo_repeat_list(value) -> bool:
+    return (
+        isinstance(value, list)
+        and value
+        and all(isinstance(item, dict) for item in value)
+        and all(any(isinstance(k, str) and "/" in k for k in item) for item in value)
+    )
+
+
+def _is_kobo_field_list_dict(value) -> bool:
+    return (
+        isinstance(value, dict)
+        and value
+        and all(isinstance(k, str) and "/" in k for k in value)
+        and not any(k.startswith("_") for k in value)
+    )
+
+
+def _flatten_group_items(parent_key: str, items: list[dict]) -> dict:
+    flat = {}
+    for index, item in enumerate(items, start=1):
+        for slash_key, field_value in item.items():
+            flat[f"{parent_key}/{index}/{_leaf_key(slash_key)}"] = field_value
+    return flat
+
+
+def flatten_kobotoolbox_submission(submission, form_metadata=None):
+    """Flatten Kobo repeat-group and field-list payloads into wide slash-separated keys.
+
+    Repeat groups and matrix questions arrive as ``list[dict]`` values with long
+    slash-separated keys. Field-list groups may arrive as a lone ``dict`` with
+    slash keys. Both are expanded to ``{group}/{index}/{leaf_key}`` (1-based index).
+
+    Parameters
+    ----------
+    submission : dict
+        A single KoboToolbox submission record.
+    form_metadata : dict, optional
+        Form metadata from the Kobo API. Reserved for future use to strip redundant
+        internal group segments via ``content.survey`` (begin_repeat / matrix types).
+
+    Returns
+    -------
+    dict
+        A flattened copy of the submission with repeat/field-list blobs expanded.
+    """
+    _ = form_metadata  # TODO: use content.survey to refine leaf_key / group segments
+    flat = {}
+    for key, value in submission.items():
+        if _is_kobo_repeat_list(value):
+            flat.update(_flatten_group_items(key, value))
+        elif _is_kobo_field_list_dict(value):
+            flat.update(_flatten_group_items(key, [value]))
+        else:
+            flat[key] = value
+    return flat
+
+
+def transform_kobotoolbox_form_data(
+    form_data, form_name=None, form_languages=None, form_metadata=None
+):
     """Transform KoboToolbox form data by adding metadata fields and formatting geometry for SQL database insertion.
 
     Parameters
@@ -353,13 +418,18 @@ def transform_kobotoolbox_form_data(form_data, form_name=None, form_languages=No
         The name of the form from metadata. If provided, adds 'dataset_name' field to each submission.
     form_languages : str, optional
         Comma-separated list of form languages. If provided, adds 'form_translations' field to each submission.
+    form_metadata : dict, optional
+        Form metadata from the Kobo API, passed to repeat-group flattening.
 
     Returns
     -------
     list
         A list of transformed form submissions with added metadata fields and formatted geometry.
     """
-    for submission in form_data:
+    for i, submission in enumerate(form_data):
+        submission = flatten_kobotoolbox_submission(submission, form_metadata)
+        form_data[i] = submission
+
         # Add metadata fields if provided
         if form_name:
             submission["dataset_name"] = form_name

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -13,6 +13,7 @@ import requests
 
 from f.common_logic.db_operations import StructuredDBWriter, conninfo, postgresql
 from f.common_logic.file_operations import save_data_to_file
+from f.connectors.csv.csv_to_postgres import main as save_csv_to_postgres
 
 
 # https://hub.windmill.dev/resource_types/193/kobotoolbox_account
@@ -56,13 +57,24 @@ def main(
         form_languages=form_languages,
     )
 
-    kobo_response_writer = StructuredDBWriter(
-        conninfo(db),
+    save_path = Path(attachment_root) / db_table_name
+    save_data_to_file(
+        transformed_form_responses,
         db_table_name,
+        save_path,
+        file_type="csv",
+    )
+
+    save_csv_to_postgres(
+        db,
+        db_table_name,
+        str(Path(db_table_name) / f"{db_table_name}.csv"),
+        attachment_root,
+        delete_csv_file=False,
+        id_column="_id",
         use_mapping_table=True,
         reverse_properties_separated_by="/",
     )
-    kobo_response_writer.handle_output(transformed_form_responses)
     logger.info(
         f"KoboToolbox responses successfully written to database table: [{db_table_name}]"
     )

--- a/f/connectors/kobotoolbox/tests/assets/server_responses.py
+++ b/f/connectors/kobotoolbox/tests/assets/server_responses.py
@@ -1,6 +1,8 @@
 import posixpath
 from urllib.parse import urlencode
 
+nested_form_id = "fixture_nested_household"
+
 
 def kobo_form(uri, form_id, form_name):
     return {
@@ -213,6 +215,186 @@ def _get_all_submissions(uri, form_id):
         ]
 
 
+def kobo_form_nested(uri, form_id, form_name="Household Survey Fixture"):
+  """Form metadata with repeat groups and field-list groups for flattening tests."""
+  return {
+    "name": form_name,
+    "uid": form_id,
+    "owner__username": "fixture_user",
+    "data": posixpath.join(uri, "api/v2/assets", form_id, "data/"),
+    "content": {
+      "schema": "1",
+      "survey": [
+        {
+          "name": "village_name",
+          "type": "text",
+          "label": ["Village name"],
+          "$qpath": "village_name",
+          "$xpath": "village_name",
+          "$autoname": "village_name",
+        },
+        {
+          "name": "interviewer_name",
+          "type": "text",
+          "label": ["Interviewer name"],
+          "$qpath": "interviewer_name",
+          "$xpath": "interviewer_name",
+          "$autoname": "interviewer_name",
+        },
+        {
+          "name": "household_members",
+          "type": "begin_repeat",
+          "label": ["Household members"],
+          "$qpath": "household_members",
+          "$xpath": "household_members",
+          "$autoname": "household_members",
+        },
+        {
+          "name": "group_fixture_member_1",
+          "type": "begin_group",
+          "label": ["Member"],
+          "$qpath": "household_members/group_fixture_member_1",
+          "$xpath": "household_members/group_fixture_member_1",
+          "$autoname": "group_fixture_member_1",
+        },
+        {
+          "name": "group_fixture_member_1_name",
+          "type": "text",
+          "label": ["Member name"],
+          "$qpath": "household_members/group_fixture_member_1/group_fixture_member_1_name",
+          "$xpath": "household_members/group_fixture_member_1/group_fixture_member_1_name",
+          "$autoname": "group_fixture_member_1_name",
+        },
+        {
+          "name": "group_fixture_member_1_age",
+          "type": "integer",
+          "label": ["Member age"],
+          "$qpath": "household_members/group_fixture_member_1/group_fixture_member_1_age",
+          "$xpath": "household_members/group_fixture_member_1/group_fixture_member_1_age",
+          "$autoname": "group_fixture_member_1_age",
+        },
+        {"type": "end_group"},
+        {"type": "end_repeat"},
+        {
+          "name": "dwelling_counts",
+          "type": "begin_group",
+          "label": ["Dwelling counts"],
+          "$qpath": "dwelling_counts",
+          "$xpath": "dwelling_counts",
+          "$autoname": "dwelling_counts",
+        },
+        {
+          "name": "group_fixture_house_adults",
+          "type": "integer",
+          "label": ["Adults"],
+          "$qpath": "dwelling_counts/group_fixture_house/group_fixture_house_adults",
+          "$xpath": "dwelling_counts/group_fixture_house/group_fixture_house_adults",
+          "$autoname": "group_fixture_house_adults",
+        },
+        {
+          "name": "group_fixture_house_children",
+          "type": "integer",
+          "label": ["Children"],
+          "$qpath": "dwelling_counts/group_fixture_house/group_fixture_house_children",
+          "$xpath": "dwelling_counts/group_fixture_house/group_fixture_house_children",
+          "$autoname": "group_fixture_house_children",
+        },
+        {"type": "end_group"},
+      ],
+      "choices": [],
+      "settings": {"version": "1", "default_language": "English (en)"},
+      "translated": ["label"],
+      "translations": [None],
+    },
+  }
+
+
+def _get_nested_submissions(uri, form_id):
+  """Return synthetic submissions with repeat groups and field-list dicts."""
+  return [
+    {
+      "_id": 900001,
+      "formhub/uuid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "village_name": "Village Alpha",
+      "interviewer_name": "Interviewer A",
+      "household_members": [
+        {
+          "household_members/group_fixture_member_1/group_fixture_member_1_name": "Person One",
+          "household_members/group_fixture_member_1/group_fixture_member_1_age": "25",
+        },
+        {
+          "household_members/group_fixture_member_1/group_fixture_member_1_name": "Person Two",
+          "household_members/group_fixture_member_1/group_fixture_member_1_age": "30",
+        },
+      ],
+      "summary_counts/adults": "2",
+      "__version__": "fixtureVersion01",
+      "meta/instanceID": "uuid:11111111-1111-1111-1111-111111111111",
+      "_xform_id_string": form_id,
+      "_uuid": "11111111-1111-1111-1111-111111111111",
+      "_attachments": [],
+      "_status": "submitted_via_web",
+      "_geolocation": [10.0, 20.0],
+      "_submission_time": "2026-01-15T10:00:00",
+      "_tags": [],
+      "_notes": [],
+      "_validation_status": {},
+      "_submitted_by": "fixture_user",
+    },
+    {
+      "_id": 900002,
+      "formhub/uuid": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "village_name": "Village Beta",
+      "interviewer_name": "Interviewer B",
+      "household_members": [
+        {
+          "household_members/group_fixture_member_1/group_fixture_member_1_name": "Person Three",
+          "household_members/group_fixture_member_1/group_fixture_member_1_age": "40",
+        },
+      ],
+      "dwelling_counts": {
+        "dwelling_counts/group_fixture_house/group_fixture_house_adults": "2",
+        "dwelling_counts/group_fixture_house/group_fixture_house_children": "1",
+      },
+      "__version__": "fixtureVersion01",
+      "meta/instanceID": "uuid:22222222-2222-2222-2222-222222222222",
+      "_xform_id_string": form_id,
+      "_uuid": "22222222-2222-2222-2222-222222222222",
+      "_attachments": [],
+      "_status": "submitted_via_web",
+      "_submission_time": "2026-01-15T11:00:00",
+      "_tags": [],
+      "_notes": [],
+      "_validation_status": {},
+      "_submitted_by": "fixture_user",
+    },
+  ]
+
+
+def _paginate_submissions(uri, form_id, all_submissions, limit=100, start=0):
+  total_count = len(all_submissions)
+  end = start + limit
+  results = all_submissions[start:end]
+
+  next_url = None
+  if end < total_count:
+    next_params = {"limit": limit, "start": end}
+    next_url = f"{uri}/api/v2/assets/{form_id}/data/?{urlencode(next_params)}"
+
+  previous_url = None
+  if start > 0:
+    prev_start = max(0, start - limit)
+    prev_params = {"limit": limit, "start": prev_start}
+    previous_url = f"{uri}/api/v2/assets/{form_id}/data/?{urlencode(prev_params)}"
+
+  return {
+    "count": total_count,
+    "next": next_url,
+    "previous": previous_url,
+    "results": results,
+  }
+
+
 def kobo_form_submissions(uri, form_id, limit=100, start=0):
     """
     Return paginated form submissions for testing.
@@ -233,29 +415,13 @@ def kobo_form_submissions(uri, form_id, limit=100, start=0):
     dict
         A paginated response with count, next, previous, and results
     """
-    all_submissions = _get_all_submissions(uri, form_id)
-    total_count = len(all_submissions)
-    
-    # Paginate results
-    end = start + limit
-    results = all_submissions[start:end]
-    
-    # Build next URL if there are more results
-    next_url = None
-    if end < total_count:
-        next_params = {"limit": limit, "start": end}
-        next_url = f"{uri}/api/v2/assets/{form_id}/data/?{urlencode(next_params)}"
-    
-    # Build previous URL if we're not on the first page
-    previous_url = None
-    if start > 0:
-        prev_start = max(0, start - limit)
-        prev_params = {"limit": limit, "start": prev_start}
-        previous_url = f"{uri}/api/v2/assets/{form_id}/data/?{urlencode(prev_params)}"
-    
-    return {
-        "count": total_count,
-        "next": next_url,
-        "previous": previous_url,
-        "results": results,
-    }
+    return _paginate_submissions(
+        uri, form_id, _get_all_submissions(uri, form_id), limit, start
+    )
+
+
+def kobo_nested_form_submissions(uri, form_id, limit=100, start=0):
+  """Return paginated nested-form submissions for flattening tests."""
+  return _paginate_submissions(
+    uri, form_id, _get_nested_submissions(uri, form_id), limit, start
+  )

--- a/f/connectors/kobotoolbox/tests/conftest.py
+++ b/f/connectors/kobotoolbox/tests/conftest.py
@@ -38,6 +38,22 @@ def _paginated_data_callback(request):
     return (200, {}, json.dumps(response_data))
 
 
+def _paginated_nested_data_callback(request):
+    """Paginated data callback for the nested repeat-group fixture form."""
+    import urllib.parse
+
+    parsed_url = urllib.parse.urlparse(request.url)
+    query_params = urllib.parse.parse_qs(parsed_url.query)
+    limit = int(query_params.get("limit", [100])[0])
+    start = int(query_params.get("start", [0])[0])
+
+    response_data = server_responses.kobo_nested_form_submissions(
+        server_url, server_responses.nested_form_id, limit=limit, start=start
+    )
+
+    return (200, {}, json.dumps(response_data))
+
+
 def _register_common_mocks(rsps, form_id, metadata):
     rsps.get(
         f"{server_url}/api/v2/assets/{form_id}/",
@@ -94,6 +110,35 @@ def koboserver_with_pagination(mocked_responses):
     _register_common_mocks(mocked_responses, form_id, metadata)
     
     return _build_koboserver_fixture(metadata)
+
+
+@pytest.fixture
+def koboserver_nested(mocked_responses):
+    """Fixture with repeat groups and field-list dict payloads for flattening tests."""
+    nested_id = server_responses.nested_form_id
+    metadata = server_responses.kobo_form_nested(server_url, nested_id)
+
+    mocked_responses.get(
+        f"{server_url}/api/v2/assets/{nested_id}/",
+        json=metadata,
+        status=200,
+    )
+    mocked_responses.add_callback(
+        responses.GET,
+        re.compile(rf"{server_url}/api/v2/assets/{nested_id}/data/"),
+        callback=_paginated_nested_data_callback,
+        content_type="application/json",
+    )
+
+    @dataclass
+    class KoboServer:
+        account: dict
+        form_id: str
+
+    return KoboServer(
+        dict(server_url=server_url, api_key="Callooh!Callay!"),
+        nested_id,
+    )
 
 
 @pytest.fixture

--- a/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
+++ b/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
@@ -32,6 +32,20 @@ def test_script_e2e(koboserver, pg_database, tmp_path):
         key in metadata for key in ["name", "uid", "owner__username", "data", "content"]
     )
 
+    # CSV artifact is also saved to disk, mirroring the GeoJSON-to-Postgres flow
+    csv_file = asset_storage / table_name / f"{table_name}.csv"
+    assert csv_file.exists()
+    with csv_file.open(newline="", encoding="utf-8") as f:
+        csv_rows = list(csv.DictReader(f))
+    assert len(csv_rows) == 3
+    assert {r["_id"] for r in csv_rows} >= {"124961136"}
+    # Coordinates are JSON-encoded so they round-trip through csv_to_postgres
+    geo_row = next(r for r in csv_rows if r["_id"] == "124961136")
+    assert geo_row["g__coordinates"] == "[-122.0109429, 36.97012]"
+    # Nested keys preserved verbatim in the CSV header; the / -> __ reversal
+    # only happens during csv_to_postgres -> DB insertion.
+    assert "meta/instanceID" in csv_rows[0]
+
     # Survey responses are written to a SQL Table
     with psycopg.connect(autocommit=True, **pg_database) as conn:
         with conn.cursor() as cursor:

--- a/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
+++ b/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import psycopg
 
 from f.connectors.kobotoolbox.kobotoolbox_responses import (
+    flatten_kobotoolbox_submission,
     main,
     transform_kobotoolbox_form_data,
 )
@@ -70,6 +71,12 @@ def test_script_e2e(koboserver, pg_database, tmp_path):
                 f"SELECT COUNT(*) FROM {table_name}__columns WHERE original_column = 'meta/instanceID' AND sql_column = 'instanceID__meta'"
             )
             assert cursor.fetchone()[0] == 1
+
+            # Kobo system fields keep their underscores in SQL column names
+            cursor.execute(
+                f'SELECT "_status", "__version__" FROM {table_name} WHERE _id = \'124961136\''
+            )
+            assert cursor.fetchone() == ("submitted_via_web", "vLnrnT6Pvzgeh4DVfj6eDz")
 
     # Form labels are written to a SQL Table
     with psycopg.connect(autocommit=True, **pg_database) as conn:
@@ -216,3 +223,101 @@ def test_pagination(koboserver_with_pagination, pg_database, tmp_path):
             assert "124961136" in ids
             assert "125283733" in ids
             assert "125340283" in ids
+
+
+def test_flatten_kobotoolbox_submission__repeat_group():
+    submission = {
+        "household_members": [
+            {
+                "household_members/group_fixture_member_1/group_fixture_member_1_name": "Person One",
+                "household_members/group_fixture_member_1/group_fixture_member_1_age": "25",
+            },
+            {
+                "household_members/group_fixture_member_1/group_fixture_member_1_name": "Person Two",
+                "household_members/group_fixture_member_1/group_fixture_member_1_age": "30",
+            },
+        ],
+    }
+    result = flatten_kobotoolbox_submission(submission)
+
+    assert "household_members" not in result
+    assert result["household_members/1/group_fixture_member_1_name"] == "Person One"
+    assert result["household_members/1/group_fixture_member_1_age"] == "25"
+    assert result["household_members/2/group_fixture_member_1_name"] == "Person Two"
+    assert result["household_members/2/group_fixture_member_1_age"] == "30"
+
+
+def test_flatten_kobotoolbox_submission__field_list_dict():
+    submission = {
+        "dwelling_counts": {
+            "dwelling_counts/group_fixture_house/group_fixture_house_adults": "2",
+            "dwelling_counts/group_fixture_house/group_fixture_house_children": "1",
+        },
+    }
+    result = flatten_kobotoolbox_submission(submission)
+
+    assert "dwelling_counts" not in result
+    assert result["dwelling_counts/1/group_fixture_house_adults"] == "2"
+    assert result["dwelling_counts/1/group_fixture_house_children"] == "1"
+
+
+def test_flatten_kobotoolbox_submission__preserves_system_fields():
+    submission = {
+        "_id": 1,
+        "_geolocation": [10.0, 20.0],
+        "_attachments": [{"download_url": "http://example.org/file.jpg", "filename": "file.jpg"}],
+        "_validation_status": {},
+        "_tags": [],
+        "summary_counts/adults": "2",
+        "household_members": [],
+    }
+    result = flatten_kobotoolbox_submission(submission)
+
+    assert result["_id"] == 1
+    assert result["_geolocation"] == [10.0, 20.0]
+    assert result["_attachments"] == submission["_attachments"]
+    assert result["_validation_status"] == {}
+    assert result["_tags"] == []
+    assert result["summary_counts/adults"] == "2"
+    assert result["household_members"] == []
+
+
+def test_script_e2e__nested_repeats(koboserver_nested, pg_database, tmp_path):
+    asset_storage = tmp_path / "datalake"
+    table_name = "kobo_nested_repeats"
+
+    main(
+        koboserver_nested.account,
+        koboserver_nested.form_id,
+        pg_database,
+        table_name,
+        asset_storage,
+    )
+
+    csv_file = asset_storage / table_name / f"{table_name}.csv"
+    assert csv_file.exists()
+    with csv_file.open(newline="", encoding="utf-8") as f:
+        csv_rows = list(csv.DictReader(f))
+
+    assert len(csv_rows) == 2
+    assert "household_members" not in csv_rows[0]
+    assert csv_rows[0]["household_members/1/group_fixture_member_1_name"] == "Person One"
+    assert csv_rows[0]["household_members/2/group_fixture_member_1_age"] == "30"
+    assert csv_rows[1]["dwelling_counts/1/group_fixture_house_adults"] == "2"
+
+    with psycopg.connect(autocommit=True, **pg_database) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+            assert cursor.fetchone()[0] == 2
+
+            cursor.execute(
+                f'SELECT "group_fixture_member_1_name__1__household_members" '
+                f"FROM {table_name} WHERE _id = '900001'"
+            )
+            assert cursor.fetchone()[0] == "Person One"
+
+            cursor.execute(
+                f'SELECT "group_fixture_house_adults__1__dwelling_counts" '
+                f"FROM {table_name} WHERE _id = '900002'"
+            )
+            assert cursor.fetchone()[0] == "2"

--- a/f/connectors/odk/odk_responses.py
+++ b/f/connectors/odk/odk_responses.py
@@ -254,6 +254,8 @@ def _extract_coordinates_from_submission(submission):
 def transform_odk_form_data(form_data, form_name=None):
     """Transform ODK form data by adding metadata fields and formatting geometry for SQL database insertion.
 
+    # TODO: flatten ODK repeat groups / matrix payloads (sister issue to Kobo flattening)
+
     Note that ODK also stores altitude in the coordinates array, but we are only interested in extracting lat/long.
     The location object is preserved in the transformed data in case it is needed.
 

--- a/f/connectors/odk/odk_responses.py
+++ b/f/connectors/odk/odk_responses.py
@@ -10,7 +10,9 @@ from typing import TypedDict
 
 from pyodk.client import Client
 
-from f.common_logic.db_operations import StructuredDBWriter, conninfo, postgresql
+from f.common_logic.db_operations import postgresql
+from f.common_logic.file_operations import save_data_to_file
+from f.connectors.csv.csv_to_postgres import main as save_csv_to_postgres
 
 
 # https://hub.windmill.dev/resource_types/272/odk_config
@@ -76,13 +78,24 @@ def main(
 
         transformed_form_data = transform_odk_form_data(form_data, form_name=form_id)
 
-        db_writer = StructuredDBWriter(
-            conninfo(db),
+        save_path = Path(attachment_root) / db_table_name
+        save_data_to_file(
+            transformed_form_data,
             db_table_name,
+            save_path,
+            file_type="csv",
+        )
+
+        save_csv_to_postgres(
+            db,
+            db_table_name,
+            str(Path(db_table_name) / f"{db_table_name}.csv"),
+            attachment_root,
+            delete_csv_file=False,
+            id_column="_id",
             use_mapping_table=True,
             reverse_properties_separated_by="/",
         )
-        db_writer.handle_output(transformed_form_data)
 
         logger.info(
             f"ODK responses successfully written to database table: [{db_table_name}]"

--- a/f/connectors/odk/tests/odk_responses_test.py
+++ b/f/connectors/odk/tests/odk_responses_test.py
@@ -21,6 +21,24 @@ def test_script_e2e(odkserver, pg_database, tmp_path):
     # Attachments are saved to disk
     assert (asset_storage / table_name / "attachments" / "1739327186781.m4a").exists()
 
+    # CSV artifact is also saved to disk, mirroring the GeoJSON-to-Postgres flow
+    csv_file = asset_storage / table_name / f"{table_name}.csv"
+    assert csv_file.exists()
+    with csv_file.open(newline="", encoding="utf-8") as f:
+        csv_rows = list(csv.DictReader(f))
+    assert len(csv_rows) == 3
+    assert "_id" in csv_rows[0]
+    assert {r["_id"] for r in csv_rows} >= {
+        "uuid:cb7955d8-dc7c-480f-9699-20555a155c92"
+    }
+    # Coordinates are JSON-encoded in the CSV cell so they round-trip into DB
+    geo_row = next(
+        r
+        for r in csv_rows
+        if r["_id"] == "uuid:cb7955d8-dc7c-480f-9699-20555a155c92"
+    )
+    assert geo_row["g__coordinates"] == "[-77.9867385, 40.322394]"
+
     # Survey responses are written to a SQL Table
     with psycopg.connect(autocommit=True, **pg_database) as conn:
         with conn.cursor() as cursor:


### PR DESCRIPTION
## Goal


## Screenshots


## What I changed and why


## How I convinced myself this is right


## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->
