### PR TITLE
Remove stripping of underscores, and improve edge case handling, in `normalize_identifier`

### DIFF
--- a/f/common_logic/identifier_utils.py
+++ b/f/common_logic/identifier_utils.py
@@ -103,12 +103,11 @@ def normalize_identifier(
     'my_project_name'
     >>> normalize_identifier("123weird$name", ensure_leading_alpha=True)
     '_123weirdname'
+    >>> normalize_identifier("___name___")
+    '___name___'
     See tests for more examples.
     """
-    # Special case: preserve '_id' as-is (primary key field)
-    if name == "_id":
-        return "_id"
-
+    original_name = name
     normalized = unicodedata.normalize("NFD", name)
     name = "".join(ch for ch in normalized if unicodedata.category(ch) != "Mn")
 
@@ -119,7 +118,12 @@ def normalize_identifier(
         name = re.sub(r"[ \-./]", "", name)
     else:
         name = re.sub(r"[ \-./]", "_", name)
-    name = re.sub(r"[^a-zA-Z0-9_]", "", name).strip("_")
+    name = re.sub(r"[^a-zA-Z0-9_]", "", name)
+    if not original_name.startswith("_"):
+        name = name.lstrip("_")
+    if not original_name.endswith("_"):
+        name = name.rstrip("_")
+    name = name if name.strip("_") else "_"
 
     if ensure_leading_alpha and not re.match(r"^[a-zA-Z_]", name or ""):
         name = "_" + (name or "")

--- a/f/common_logic/identifier_utils.py
+++ b/f/common_logic/identifier_utils.py
@@ -107,7 +107,14 @@ def normalize_identifier(
     '___name___'
     See tests for more examples.
     """
+    if maxlen < 1:
+        raise ValueError("maxlen must be at least 1")
+
+    if sep_policy not in {"underscore", "remove"}:
+        raise ValueError("sep_policy must be 'underscore' or 'remove'")
+
     original_name = name
+
     normalized = unicodedata.normalize("NFD", name)
     name = "".join(ch for ch in normalized if unicodedata.category(ch) != "Mn")
 
@@ -118,17 +125,20 @@ def normalize_identifier(
         name = re.sub(r"[ \-./]", "", name)
     else:
         name = re.sub(r"[ \-./]", "_", name)
+
     name = re.sub(r"[^a-zA-Z0-9_]", "", name)
+
     if not original_name.startswith("_"):
         name = name.lstrip("_")
     if not original_name.endswith("_"):
         name = name.rstrip("_")
+
     name = name if name.strip("_") else "_"
 
     if ensure_leading_alpha and not re.match(r"^[a-zA-Z_]", name or ""):
         name = "_" + (name or "")
 
-    return (name or "_")[:maxlen]
+    return name[:maxlen]
 
 
 def sanitize_sql_message(

--- a/f/common_logic/tests/identifier_utils_test.py
+++ b/f/common_logic/tests/identifier_utils_test.py
@@ -1,3 +1,5 @@
+from pytest import raises as pytest_raises
+
 from f.common_logic.identifier_utils import (
     camel_to_snake,
     normalize_and_snakecase_keys,
@@ -201,7 +203,7 @@ def test_normalize_identifier_maxlen_param():
     assert normalize_identifier("a", maxlen=1) == "a"
 
     # Test maxlen=0 edge case
-    assert normalize_identifier("test", maxlen=0) == ""
+    pytest_raises(ValueError, normalize_identifier, "test", maxlen=0)
 
 
 def test_normalize_identifier_make_snake_param():

--- a/f/common_logic/tests/identifier_utils_test.py
+++ b/f/common_logic/tests/identifier_utils_test.py
@@ -37,6 +37,22 @@ def test_sanitize_sql_message():
     }
 
 
+def test_sanitize_sql_message__kobo_metadata_columns():
+    """System fields keep their leading/trailing underscores in SQL column names."""
+    message = {
+        "_status": "submitted_via_web",
+        "__version__": "abc123",
+        "_uuid": "11111111-1111-1111-1111-111111111111",
+    }
+    sql_message, mapping = sanitize_sql_message(message, {})
+    assert sql_message == message
+    assert mapping == {
+        "_status": "_status",
+        "__version__": "__version__",
+        "_uuid": "_uuid",
+    }
+
+
 def test_sanitize_sql_message__same_letters():
     message = {"foo[bar]test": 1, "foo{bar}test": 2}
 
@@ -146,15 +162,15 @@ def test_normalize_and_snakecase_keys():
 
 def test_normalize_identifier_default_params():
     """Test default parameters and core functionality."""
-    # Test special case: _id preservation
-    assert normalize_identifier("_id") == "_id"
 
-    # Test basic transformations
     assert normalize_identifier("kebab-case") == "kebab_case"
     assert normalize_identifier("123project") == "_123project"
     assert normalize_identifier("") == "_"
     assert normalize_identifier("!@#$%") == "_"
-    assert normalize_identifier("___name___") == "name"
+    assert normalize_identifier("___name___") == "___name___"
+    assert normalize_identifier("_id") == "_id"
+    assert normalize_identifier("_status", make_snake=False) == "_status"
+    assert normalize_identifier("__version__", make_snake=False) == "__version__"
     assert normalize_identifier("This is my dataset, ok?") == "this_is_my_dataset_ok"
     assert normalize_identifier("Foo bar baz") == "foo_bar_baz"
     assert normalize_identifier("Summary of results (Q1)") == "summary_of_results_q1"
@@ -220,7 +236,7 @@ def test_normalize_identifier_ensure_leading_alpha_param():
 
     # Test strings that already start with alpha - should be unchanged
     assert normalize_identifier("valid_name") == "valid_name"
-    assert normalize_identifier("_underscore") == "underscore"
+    assert normalize_identifier("_underscore") == "_underscore"
 
 
 def test_normalize_identifier_sep_policy_param():
@@ -303,7 +319,7 @@ def test_normalize_identifier_edge_cases():
 
     # Only underscores
     assert normalize_identifier("___") == "_"
-    assert normalize_identifier("___name___") == "name"
+    assert normalize_identifier("___name___") == "___name___"
 
     # Very short maxlen
     assert normalize_identifier("test", maxlen=1) == "t"


### PR DESCRIPTION
## Goal

https://github.com/ConservationMetrics/gc-scripts-hub/pull/134 introduced a `normalize_identifier` function, which  was then later added by https://github.com/ConservationMetrics/gc-scripts-hub/pull/201 to normalize primary keys:

https://github.com/ConservationMetrics/gc-scripts-hub/blob/4ae90e60f2177b58e7eec022d7024767d50f4b84/f/common_logic/db_operations.py#L338

The [`normalize_identifier`](https://github.com/ConservationMetrics/gc-scripts-hub/blob/4ae90e60f2177b58e7eec022d7024767d50f4b84/f/common_logic/identifier_utils.py#L63-L127) function, as it was written, strips any underscores, and made a special case exception for an `_id` field.

This actually had an undesirable effect. For sources like Kobo, leading and trailing underscores have a special significance to distinguish between form fields (the ones created by the user) and metadata fields (like `_submitted_by`, `__version__`). The code as it stands strips those underscores, leading to both an inability to distinguish, and possible collisions.

## What I changed and why

- This PR seeks to address the above undesirable effect by not stripping leading or trailing `_`.
- I also removed the `_id` special case, since the code change would leave this field intact.
- While here, I sought fit to address possible edge cases where `maxlen = 0` (which doesn't make any sense for an identifier) and if for some reason, `sep_policy` is set to anything other than the two accepted values.

## How I convinced myself this is right

I think trailing or leading underscores often are used to distinguish between different kinds of fields, and we should not be stripping these.

## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None