### PR TITLE
Improve save CSV to disk script, and apply for survey tools

### DIFF
--- a/f/common_logic/file_operations.py
+++ b/f/common_logic/file_operations.py
@@ -71,6 +71,22 @@ def get_safe_file_path(storage_path: str, db_table_name: str, file_type: str):
     return file_path
 
 
+def _serialize_csv_cell(value):
+    """Serialize a Python value for a CSV cell.
+
+    Lists and dicts are JSON-encoded so they round-trip with how
+    ``StructuredDBWriter`` persists complex values to TEXT columns. ``None``
+    becomes an empty string (which downstream readers like
+    ``csv_to_postgres.transform_csv_data`` translate back to ``None``).
+    Other values are written as-is.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, (list, dict)):
+        return json.dumps(value)
+    return value
+
+
 def save_data_to_file(data, filename: str, storage_path: str, file_type: str = "json"):
     """
     Saves the provided data to a file in the specified format and storage path.
@@ -78,7 +94,9 @@ def save_data_to_file(data, filename: str, storage_path: str, file_type: str = "
     Parameters
     ----------
     data : list or dict
-        The data to be saved. For CSV, should be a list of rows including a header.
+        The data to be saved. For CSV, may be either a list of rows (each row a
+        list of cells, with the first row being the header) or a list of dicts
+        (header is the union of keys with ``_id`` first when present).
     filename : str
         The name of the file to save the data to, without extension.
     storage_path : str
@@ -103,8 +121,21 @@ def save_data_to_file(data, filename: str, storage_path: str, file_type: str = "
             json.dump(data, f)
     elif file_type == "csv":
         with file_path.open("w", newline="") as f:
-            writer = csv.writer(f, quoting=csv.QUOTE_NONNUMERIC)
-            writer.writerows(data)
+            if isinstance(data[0], dict):
+                other_keys = sorted({k for row in data for k in row if k != "_id"})
+                has_id = any("_id" in row for row in data)
+                fieldnames = (["_id"] + other_keys) if has_id else other_keys
+                writer = csv.DictWriter(
+                    f, fieldnames=fieldnames, quoting=csv.QUOTE_NONNUMERIC
+                )
+                writer.writeheader()
+                for row in data:
+                    writer.writerow(
+                        {k: _serialize_csv_cell(row.get(k)) for k in fieldnames}
+                    )
+            else:
+                writer = csv.writer(f, quoting=csv.QUOTE_NONNUMERIC)
+                writer.writerows(data)
     else:
         raise ValueError(f"Unsupported file type: {file_type}")
 

--- a/f/common_logic/tests/file_operations_test.py
+++ b/f/common_logic/tests/file_operations_test.py
@@ -47,6 +47,43 @@ def test_save_data_to_file__csv_empty(tmp_path: Path):
     assert not file_path.exists()
 
 
+def test_save_data_to_file__csv_list_of_dicts(tmp_path: Path):
+    """list[dict] CSV mode: _id first, sorted rest; lists/dicts JSON-encoded;
+    None becomes an empty cell (so csv_to_postgres can round-trip to NULL)."""
+    data = [
+        {
+            "_id": "a",
+            "name": "Alpha",
+            "tags": ["x", "y"],
+            "geo": {"type": "Point", "coordinates": [1, 2]},
+        },
+        {"_id": "b", "name": "Bravo"},
+    ]
+    save_data_to_file(data, "test", tmp_path, "csv")
+
+    rows = list(read_csv_to_list(tmp_path / "test.csv"))
+    assert [r["_id"] for r in rows] == ["a", "b"]
+    # _id first, remaining keys sorted alphabetically
+    assert list(rows[0].keys()) == ["_id", "geo", "name", "tags"]
+    # Complex values land as JSON strings
+    assert rows[0]["tags"] == '["x", "y"]'
+    assert rows[0]["geo"] == '{"type": "Point", "coordinates": [1, 2]}'
+    # Missing key in the second row is written as empty cell
+    assert rows[1]["tags"] == ""
+    assert rows[1]["geo"] == ""
+
+
+def test_save_data_to_file__csv_list_of_dicts_no_id(tmp_path: Path):
+    """When no row has an _id key, header is just the sorted union of keys."""
+    data = [{"name": "Alpha"}, {"name": "Bravo", "extra": "data"}]
+    save_data_to_file(data, "test", tmp_path, "csv")
+
+    rows = list(read_csv_to_list(tmp_path / "test.csv"))
+    assert list(rows[0].keys()) == ["extra", "name"]
+    assert rows[0]["extra"] == ""
+    assert rows[1]["extra"] == "data"
+
+
 def test_save_uploaded_file_to_temp__single_file(tmp_path: Path):
     input_path = tmp_path / "sample.csv"
     input_path.write_text("col1,col2\nval1,val2")

--- a/f/connectors/csv/csv_to_postgres.py
+++ b/f/connectors/csv/csv_to_postgres.py
@@ -18,6 +18,8 @@ def main(
     attachment_root: str = "/persistent-storage/datalake/",
     delete_csv_file: bool = False,
     id_column: str = None,
+    use_mapping_table: bool = False,
+    reverse_properties_separated_by: str | None = None,
 ):
     """
     Import CSV data into PostgreSQL table.
@@ -36,6 +38,15 @@ def main(
         Whether to delete the CSV file after processing.
     id_column : str, optional
         Name of column to use as primary key. If None, auto-generates _id.
+    use_mapping_table : bool
+        Forwarded to ``StructuredDBWriter``. Enables the ``__columns`` mapping
+        table for form-style data where original column names can exceed
+        Postgres' 63-char identifier limit. Defaults to False to preserve the
+        behavior of standalone CSV uploads.
+    reverse_properties_separated_by : str, optional
+        Forwarded to ``StructuredDBWriter``. When set (e.g. ``"/"``), nested
+        keys like ``meta/instanceID`` are reversed/rejoined into SQL-safe
+        column names. Defaults to None.
     """
     csv_path = Path(attachment_root) / Path(csv_path)
     transformed_csv_data = transform_csv_data(csv_path, id_column)
@@ -43,8 +54,8 @@ def main(
     db_writer = StructuredDBWriter(
         conninfo(db),
         db_table_name,
-        use_mapping_table=False,
-        reverse_properties_separated_by=None,
+        use_mapping_table=use_mapping_table,
+        reverse_properties_separated_by=reverse_properties_separated_by,
     )
     db_writer.handle_output(transformed_csv_data)
 
@@ -55,6 +66,12 @@ def main(
 def transform_csv_data(csv_path, id_column=None):
     """
     Transform CSV data into a list of dictionaries suitable for database insertion.
+
+    Empty string cells are converted to ``None`` so that missing values land in
+    the database as ``NULL`` rather than empty TEXT. This matches the typical
+    CSV convention of "empty cell = no value" and preserves round-trip
+    semantics when a CSV is produced via ``save_data_to_file`` (which writes
+    ``None`` as an empty cell).
 
     Parameters
     ----------
@@ -71,12 +88,12 @@ def transform_csv_data(csv_path, id_column=None):
     """
     with open(csv_path, "r", encoding="utf-8") as f:
         reader = csv.DictReader(f)
-        rows = list(reader)
+        rows = [{k: (v if v != "" else None) for k, v in row.items()} for row in reader]
 
     transformed_csv_data = []
     for idx, row in enumerate(rows, 1):
         # Use specified column as _id, or generate auto-incrementing _id
-        if id_column and id_column in row:
+        if id_column and id_column in row and row[id_column] is not None:
             row_id = row[id_column]
             # Remove the original id column since we're using it as _id
             if id_column != "_id":

--- a/f/connectors/csv/csv_to_postgres.py
+++ b/f/connectors/csv/csv_to_postgres.py
@@ -39,14 +39,9 @@ def main(
     id_column : str, optional
         Name of column to use as primary key. If None, auto-generates _id.
     use_mapping_table : bool
-        Forwarded to ``StructuredDBWriter``. Enables the ``__columns`` mapping
-        table for form-style data where original column names can exceed
-        Postgres' 63-char identifier limit. Defaults to False to preserve the
-        behavior of standalone CSV uploads.
+        Forwarded to ``StructuredDBWriter``. See StructuredDBWriter documentation for more details.
     reverse_properties_separated_by : str, optional
-        Forwarded to ``StructuredDBWriter``. When set (e.g. ``"/"``), nested
-        keys like ``meta/instanceID`` are reversed/rejoined into SQL-safe
-        column names. Defaults to None.
+        Forwarded to ``StructuredDBWriter``. See StructuredDBWriter documentation for more details.
     """
     csv_path = Path(attachment_root) / Path(csv_path)
     transformed_csv_data = transform_csv_data(csv_path, id_column)

--- a/f/connectors/csv/tests/csv_to_postgres_test.py
+++ b/f/connectors/csv/tests/csv_to_postgres_test.py
@@ -1,6 +1,6 @@
 import psycopg
 
-from f.connectors.csv.csv_to_postgres import main
+from f.connectors.csv.csv_to_postgres import main, transform_csv_data
 
 csv_fixture_path = "f/connectors/csv/tests/assets/"
 
@@ -90,3 +90,60 @@ def test_script_with_custom_id_column(pg_database):
                 "Selective logging area",
                 "Moderate depletion",
             )
+
+
+def test_transform_csv_data__empty_cells_become_none(tmp_path):
+    """Empty CSV cells round-trip to ``None`` so the DB can store NULL.
+
+    This matches typical CSV conventions and preserves NULL semantics when a
+    CSV produced by ``save_data_to_file`` (which writes ``None`` as an empty
+    cell) is read back in.
+    """
+    csv_file = tmp_path / "sparse.csv"
+    csv_file.write_text("_id,name,note\n1,Alpha,\n2,,Bravo note\n")
+
+    rows = transform_csv_data(csv_file, id_column="_id")
+    assert rows == [
+        {"_id": "1", "name": "Alpha", "note": None},
+        {"_id": "2", "name": None, "note": "Bravo note"},
+    ]
+
+
+def test_script_with_mapping_table_and_key_reversal(pg_database, tmp_path):
+    """Forwarding use_mapping_table/reverse_properties_separated_by to the
+    StructuredDBWriter enables form-style ingestion (used by ODK/Kobo/Epi)."""
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text(
+        '"_id","meta/instanceID","name"\n'
+        '"abc","uuid:111","Alpha"\n'
+        '"def","uuid:222","Bravo"\n'
+    )
+
+    main(
+        pg_database,
+        "form_responses",
+        "data.csv",
+        str(tmp_path),
+        False,
+        "_id",
+        use_mapping_table=True,
+        reverse_properties_separated_by="/",
+    )
+
+    with psycopg.connect(autocommit=True, **pg_database) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT COUNT(*) FROM form_responses")
+            assert cursor.fetchone()[0] == 2
+
+            # meta/instanceID got reversed to instanceID__meta
+            cursor.execute(
+                "SELECT \"instanceID__meta\" FROM form_responses WHERE _id = 'abc'"
+            )
+            assert cursor.fetchone() == ("uuid:111",)
+
+            # Mapping table is created and recorded
+            cursor.execute(
+                "SELECT sql_column FROM form_responses__columns "
+                "WHERE original_column = 'meta/instanceID'"
+            )
+            assert cursor.fetchone() == ("instanceID__meta",)

--- a/f/connectors/epicollect/epicollect_pull.py
+++ b/f/connectors/epicollect/epicollect_pull.py
@@ -58,25 +58,30 @@ def main(
     transformed = transform_epicollect_entries(entries, form_name=form_name)
 
     save_path = Path(attachment_root) / db_table_name
-    save_data_to_file(
-        transformed,
-        db_table_name,
-        save_path,
-        file_type="csv",
-    )
+    if transformed:
+        save_data_to_file(
+            transformed,
+            db_table_name,
+            save_path,
+            file_type="csv",
+        )
 
-    save_csv_to_postgres(
-        db,
-        db_table_name,
-        str(Path(db_table_name) / f"{db_table_name}.csv"),
-        attachment_root,
-        delete_csv_file=False,
-        id_column="_id",
-        use_mapping_table=True,
-        reverse_properties_separated_by="/",
-    )
+        save_csv_to_postgres(
+            db,
+            db_table_name,
+            str(Path(db_table_name) / f"{db_table_name}.csv"),
+            attachment_root,
+            delete_csv_file=False,
+            id_column="_id",
+            use_mapping_table=True,
+            reverse_properties_separated_by="/",
+        )
 
-    logger.info(f"EpiCollect5 entries written to database table: [{db_table_name}]")
+        logger.info(f"EpiCollect5 entries written to database table: [{db_table_name}]")
+    else:
+        logger.warning(
+            f"No entries returned; skipping database write for table: [{db_table_name}]"
+        )
 
 
 def _get_access_token(client_id: int, client_secret: str) -> str:

--- a/f/connectors/epicollect/epicollect_pull.py
+++ b/f/connectors/epicollect/epicollect_pull.py
@@ -9,9 +9,9 @@ from urllib.parse import parse_qs, urlparse
 
 import requests
 
-from f.common_logic.db_operations import StructuredDBWriter, conninfo, postgresql
+from f.common_logic.db_operations import postgresql
 from f.common_logic.file_operations import save_data_to_file
-
+from f.connectors.csv.csv_to_postgres import main as save_csv_to_postgres
 
 BASE_URL = "https://five.epicollect.net"
 _MEDIA_TYPES = frozenset({"photo", "audio", "video"})
@@ -47,7 +47,9 @@ def main(
     media_fields = _extract_media_fields(project_metadata)
 
     logo_url = project_metadata.get("data", {}).get("project", {}).get("logo_url", "")
-    _download_project_logo(project_slug, logo_url, headers, db_table_name, attachment_root)
+    _download_project_logo(
+        project_slug, logo_url, headers, db_table_name, attachment_root
+    )
 
     entries = download_entries(
         project_slug, headers, db_table_name, attachment_root, media_fields
@@ -55,16 +57,26 @@ def main(
 
     transformed = transform_epicollect_entries(entries, form_name=form_name)
 
-    writer = StructuredDBWriter(
-        conninfo(db),
+    save_path = Path(attachment_root) / db_table_name
+    save_data_to_file(
+        transformed,
         db_table_name,
+        save_path,
+        file_type="csv",
+    )
+
+    save_csv_to_postgres(
+        db,
+        db_table_name,
+        str(Path(db_table_name) / f"{db_table_name}.csv"),
+        attachment_root,
+        delete_csv_file=False,
+        id_column="_id",
         use_mapping_table=True,
         reverse_properties_separated_by="/",
     )
-    writer.handle_output(transformed)
-    logger.info(
-        f"EpiCollect5 entries written to database table: [{db_table_name}]"
-    )
+
+    logger.info(f"EpiCollect5 entries written to database table: [{db_table_name}]")
 
 
 def _get_access_token(client_id: int, client_secret: str) -> str:
@@ -332,7 +344,12 @@ def download_entries(
 
         skipped = sum(
             _download_entry_media(
-                project_slug, entry, media_fields, headers, db_table_name, attachment_root
+                project_slug,
+                entry,
+                media_fields,
+                headers,
+                db_table_name,
+                attachment_root,
             )
             for entry in entries
         )
@@ -345,9 +362,7 @@ def download_entries(
         page += 1
         time.sleep(_PAGE_DELAY_S)
 
-    logger.info(
-        f"[{project_slug}] Downloaded {len(all_entries)} total entries."
-    )
+    logger.info(f"[{project_slug}] Downloaded {len(all_entries)} total entries.")
     return all_entries
 
 

--- a/f/connectors/epicollect/tests/assets/server_responses.py
+++ b/f/connectors/epicollect/tests/assets/server_responses.py
@@ -318,6 +318,11 @@ def entries_page(page: int = 1, per_page: int = 250) -> dict:
     )
 
 
+def entries_empty(page: int = 1, per_page: int = 250) -> dict:
+    """Single-page response with zero entries."""
+    return _build_entries_page([], current_page=1, last_page=1, per_page=per_page)
+
+
 def entries_paginated(page: int = 1, per_page: int = 2) -> dict:
     """Two-page response — 2 entries per page, 4 entries total."""
     all_e = _all_entries()

--- a/f/connectors/epicollect/tests/conftest.py
+++ b/f/connectors/epicollect/tests/conftest.py
@@ -126,6 +126,26 @@ def epicollect_server_paginated(mocked_responses):
 
 
 @pytest.fixture
+def epicollect_server_empty(mocked_responses):
+    """Mock EpiCollect5 server returning a single page with zero entries."""
+    _register_token_mock(mocked_responses)
+    _register_project_mock(mocked_responses)
+    mocked_responses.add_callback(
+        responses.GET,
+        re.compile(rf"{re.escape(_BASE_URL)}/api/export/entries/{re.escape(PROJECT_SLUG)}"),
+        callback=lambda _req: (200, {}, json.dumps(server_responses.entries_empty())),
+        content_type="application/json",
+    )
+    _register_media_mock(mocked_responses)
+
+    return EpiCollectServer(
+        project_slug=PROJECT_SLUG,
+        client_id=_CLIENT_ID,
+        client_secret=_CLIENT_SECRET,
+    )
+
+
+@pytest.fixture
 def epicollect_public_server(mocked_responses):
     """Mock a public EpiCollect5 project whose photo field is a full media URL."""
     public_slug = server_responses.PUBLIC_PROJECT_SLUG

--- a/f/connectors/epicollect/tests/epicollect_pull_test.py
+++ b/f/connectors/epicollect/tests/epicollect_pull_test.py
@@ -35,6 +35,10 @@ def test_script_e2e(epicollect_server, pg_database, tmp_path):
     assert (attachments / AUDIO_FILENAME).exists()
     assert (attachments / VIDEO_FILENAME).exists()
 
+    # CSV artifact is also saved to disk
+    csv_file = asset_storage / table_name / f"{table_name}.csv"
+    assert csv_file.exists()
+
     with psycopg.connect(autocommit=True, **pg_database) as conn:
         with conn.cursor() as cur:
             # Three entries returned by the single-page fixture
@@ -43,8 +47,7 @@ def test_script_e2e(epicollect_server, pg_database, tmp_path):
 
             # Geometry: lat=4.711, lon=-74.072 → GeoJSON [lon, lat]
             cur.execute(
-                f"SELECT g__type, g__coordinates FROM {table_name} "
-                f"WHERE _id = %s",
+                f"SELECT g__type, g__coordinates FROM {table_name} WHERE _id = %s",
                 (PRIMARY_UUID,),
             )
             row = cur.fetchone()

--- a/f/connectors/epicollect/tests/epicollect_pull_test.py
+++ b/f/connectors/epicollect/tests/epicollect_pull_test.py
@@ -128,6 +128,30 @@ def test_pagination(epicollect_server_paginated, pg_database, tmp_path):
             assert row[1] == "[-62.216, -3.465]"
 
 
+def test_script_e2e__no_entries(epicollect_server_empty, pg_database, tmp_path):
+    asset_storage = tmp_path / "datalake"
+    table_name = "ec5_no_entries"
+
+    # A zero-entry pull must not raise
+    main(
+        epicollect_server_empty.project_slug,
+        pg_database,
+        table_name,
+        client_id=epicollect_server_empty.client_id,
+        client_secret=epicollect_server_empty.client_secret,
+        attachment_root=asset_storage,
+    )
+
+    # No CSV artifact is written when there are no entries
+    assert not (asset_storage / table_name / f"{table_name}.csv").exists()
+
+    # No response table is created
+    with psycopg.connect(autocommit=True, **pg_database) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT to_regclass(%s)", (f"public.{table_name}",))
+            assert cur.fetchone()[0] is None
+
+
 def test_transform_no_location():
     """Entries missing a GPS fix produce no geometry fields."""
     entries = [

--- a/f/connectors/kobotoolbox/README.md
+++ b/f/connectors/kobotoolbox/README.md
@@ -18,6 +18,42 @@ Each row represents one label for a form element (from either the `survey` or `c
 
 This table can be used for rendering field translations in downstream clients, selecting the appropriate label by language, or falling back gracefully when a translation is missing.
 
+## Nested Data Flattening (repeat groups & matrices)
+
+KoboToolbox returns [repeat groups](https://support.kobotoolbox.org/group_repeat.html) and [matrix](https://support.kobotoolbox.org/matrix_response.html) questions as **lists of dicts** with long slash-separated keys. Left alone, each of these lands in a single cell that is difficult to analyze in downstream tools like Apache Superset. Before insertion, submissions are flattened into wide `{group}/{index}/{leaf}` keys (1-based index, `leaf` = last slash segment).
+
+A repeat group from the API:
+
+```json
+"household_members": [
+  { "household_members/member/member_name": "Ada",  "household_members/member/member_age": "40" },
+  { "household_members/member/member_name": "Alan", "household_members/member/member_age": "37" }
+]
+```
+
+is flattened to:
+
+```
+household_members/1/member_name = "Ada"
+household_members/1/member_age  = "40"
+household_members/2/member_name = "Alan"
+household_members/2/member_age  = "37"
+```
+
+A field-list group arrives as a lone dict and is flattened with index `1`:
+
+```json
+"dwelling_counts": { "dwelling_counts/house/house_adults": "2", "dwelling_counts/house/house_children": "1" }
+```
+```
+dwelling_counts/1/house_adults   = "2"
+dwelling_counts/1/house_children = "1"
+```
+
+The existing `reverse_properties_separated_by="/"` logic then reverses each key into a SQL column, e.g. `household_members/1/member_name` → `member_name__1__household_members`.
+
+> **Note:** The ODK connector (`f/connectors/odk/odk_responses.py`) shares this XLSForm-style plumbing but does not (yet) flatten nested payloads. See the `TODO` there.
+
 ## 📚 Reference
 
 * KoboToolbox API Documentation: https://support.kobotoolbox.org/api.html

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -347,6 +347,94 @@ def download_form_responses_and_attachments(
     return form_submissions, form_name, form_languages
 
 
+# TODO - YAGNI: Extract to f/common_logic/submission_flatten.py if/when ODK
+# flattening is required; not worth a common module until then.
+def _get_flattenable_kobo_rows(value):
+    """Return a Kobo field value as a list of rows to flatten, or ``None`` to leave it alone.
+
+    We only flatten values that look like a group of fields with slash-separated
+    keys. There are two such shapes:
+
+    A list of row dicts (repeat group / matrix), e.g.::
+
+        [
+            {"household_members/name": "Ada", ...},
+            {"household_members/name": "Bo",  ...},
+        ]
+
+    A single dict of slash keys (field-list group), e.g.::
+
+        {"location/lat": 1.0, "location/lng": 2.0}
+
+    Both are returned as a list of rows. Everything else (scalars, empty
+    containers, geolocation, attachments, and system lists/dicts like ``_tags``
+    or ``_validation_status``) returns ``None`` and is kept as-is.
+    """
+    # Every row must be a dict with at least one slash key. This excludes plain
+    # lists such as _tags, _attachments metadata, and empty repeats.
+    if (
+        isinstance(value, list)
+        and value
+        and all(isinstance(item, dict) for item in value)
+        and all(any(isinstance(k, str) and "/" in k for k in item) for item in value)
+    ):
+        return value
+
+    # A lone group dict has no repeat index, so wrap it as one row and let the
+    # same flatten loop handle it. Requiring "/" on every key excludes system
+    # dicts such as _validation_status.
+    if (
+        isinstance(value, dict)
+        and value
+        and all(isinstance(k, str) and "/" in k for k in value)
+    ):
+        return [value]
+
+    return None
+
+
+def flatten_kobotoolbox_submission(submission):
+    """Flatten Kobo repeat-group and field-list payloads into wide slash-separated keys.
+
+    Repeat groups and matrix questions arrive as ``list[dict]`` values with long
+    slash-separated keys. Field-list groups may arrive as a lone ``dict`` with
+    slash keys. Both are expanded to ``{group}/{index}/{leaf_key}`` (1-based index).
+
+    Repeat groups can be nested (a repeat inside a repeat), so flattening recurses
+    until no slash-keyed rows remain, e.g. ``{outer}/{i}/{inner}/{j}/{leaf_key}``.
+
+    Parameters
+    ----------
+    submission : dict
+        A single KoboToolbox submission record.
+
+    Returns
+    -------
+    dict
+        A flattened copy of the submission with repeat/field-list blobs expanded.
+    """
+    flat = {}
+    for key, value in submission.items():
+        rows = _get_flattenable_kobo_rows(value)
+        if rows is None:
+            flat[key] = value
+        else:
+            _flatten_kobo_rows(key, rows, flat)
+    return flat
+
+
+def _flatten_kobo_rows(prefix, rows, flat):
+    """Expand ``rows`` under ``prefix`` into ``flat``, recursing into nested repeats."""
+    for index, row in enumerate(rows, start=1):
+        for slash_key, value in row.items():
+            key = f"{prefix}/{index}/{slash_key.rsplit('/', 1)[-1]}"
+            nested = _get_flattenable_kobo_rows(value)
+            if nested is None:
+                flat[key] = value
+            else:
+                _flatten_kobo_rows(key, nested, flat)
+
+
 def transform_kobotoolbox_form_data(form_data, form_name=None, form_languages=None):
     """Transform KoboToolbox form data by adding metadata fields and formatting geometry for SQL database insertion.
 
@@ -364,7 +452,9 @@ def transform_kobotoolbox_form_data(form_data, form_name=None, form_languages=No
     list
         A list of transformed form submissions with added metadata fields and formatted geometry.
     """
-    for submission in form_data:
+    for i, submission in enumerate(form_data):
+        submission = flatten_kobotoolbox_submission(submission)
+        form_data[i] = submission
         # Add metadata fields if provided
         if form_name:
             submission["dataset_name"] = form_name

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -13,6 +13,7 @@ import requests
 
 from f.common_logic.db_operations import StructuredDBWriter, conninfo, postgresql
 from f.common_logic.file_operations import save_data_to_file
+from f.connectors.csv.csv_to_postgres import main as save_csv_to_postgres
 
 
 # https://hub.windmill.dev/resource_types/193/kobotoolbox_account
@@ -56,13 +57,24 @@ def main(
         form_languages=form_languages,
     )
 
-    kobo_response_writer = StructuredDBWriter(
-        conninfo(db),
+    save_path = Path(attachment_root) / db_table_name
+    save_data_to_file(
+        transformed_form_responses,
         db_table_name,
+        save_path,
+        file_type="csv",
+    )
+
+    save_csv_to_postgres(
+        db,
+        db_table_name,
+        str(Path(db_table_name) / f"{db_table_name}.csv"),
+        attachment_root,
+        delete_csv_file=False,
+        id_column="_id",
         use_mapping_table=True,
         reverse_properties_separated_by="/",
     )
-    kobo_response_writer.handle_output(transformed_form_responses)
     logger.info(
         f"KoboToolbox responses successfully written to database table: [{db_table_name}]"
     )

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -58,26 +58,31 @@ def main(
     )
 
     save_path = Path(attachment_root) / db_table_name
-    save_data_to_file(
-        transformed_form_responses,
-        db_table_name,
-        save_path,
-        file_type="csv",
-    )
+    if transformed_form_responses:
+        save_data_to_file(
+            transformed_form_responses,
+            db_table_name,
+            save_path,
+            file_type="csv",
+        )
 
-    save_csv_to_postgres(
-        db,
-        db_table_name,
-        str(Path(db_table_name) / f"{db_table_name}.csv"),
-        attachment_root,
-        delete_csv_file=False,
-        id_column="_id",
-        use_mapping_table=True,
-        reverse_properties_separated_by="/",
-    )
-    logger.info(
-        f"KoboToolbox responses successfully written to database table: [{db_table_name}]"
-    )
+        save_csv_to_postgres(
+            db,
+            db_table_name,
+            str(Path(db_table_name) / f"{db_table_name}.csv"),
+            attachment_root,
+            delete_csv_file=False,
+            id_column="_id",
+            use_mapping_table=True,
+            reverse_properties_separated_by="/",
+        )
+        logger.info(
+            f"KoboToolbox responses successfully written to database table: [{db_table_name}]"
+        )
+    else:
+        logger.warning(
+            f"No submissions returned; skipping database write for table: [{db_table_name}]"
+        )
 
     # If form_labels is empty, there were no translatable labels found in metadata
     if form_labels:

--- a/f/connectors/kobotoolbox/tests/assets/server_responses.py
+++ b/f/connectors/kobotoolbox/tests/assets/server_responses.py
@@ -1,6 +1,8 @@
 import posixpath
 from urllib.parse import urlencode
 
+nested_form_id = "fixture_nested_household"
+
 
 def kobo_form(uri, form_id, form_name):
     return {
@@ -97,165 +99,343 @@ def kobo_form(uri, form_id, form_name):
 def _get_all_submissions(uri, form_id):
     """Return all submission records for testing."""
     return [
-            {
-                "_id": 124961136,
-                "formhub/uuid": "f7bef041e8624f09946bff05ee5cbd4b",
-                "start": "2021-11-16T15:44:56.464-08:00",
-                "end": "2021-11-16T15:46:17.524-08:00",
-                "today": "2021-11-16",
-                "username": "cmi_admin_kobo_test",
-                "deviceid": "collect:pEo4VhQlQDnvDCNj",
-                "Record_your_current_location": "36.97012 -122.0109429 -14.432169171089349 4.969",
-                "Estimate_height_of_your_tree_in_meters": "18",
-                "I_like_this_tree_because": "shade food wildlife_habitat beauty",
-                "Take_a_photo_of_this_tree": "1637106370994.jpg",
-                "__version__": "vLnrnT6Pvzgeh4DVfj6eDz",
-                "meta/instanceID": "uuid:e58da38d-3eee-4bd7-8512-4a97ea8fbb01",
-                "_xform_id_string": form_id,
-                "_uuid": "e58da38d-3eee-4bd7-8512-4a97ea8fbb01",
-                "_attachments": [
-                    {
-                        "download_url": f"{uri}/api/v2/assets/{form_id}/data/124961136/attachments/46493730/",
-                        "download_large_url": f"{uri}/api/v2/assets/{form_id}/data/124961136/attachments/46493730/",
-                        "download_medium_url": f"{uri}/api/v2/assets/{form_id}/data/124961136/attachments/46493730/",
-                        "download_small_url": f"{uri}/api/v2/assets/{form_id}/data/124961136/attachments/46493730/",
-                        "mimetype": "image/jpeg",
-                        "filename": "cmi_admin_kobo_test/attachments/f7bef041e8624f09946bff05ee5cbd4b/e58da38d-3eee-4bd7-8512-4a97ea8fbb01/1637106370994.jpg",
-                        "instance": 124961136,
-                        "xform": 815328,
-                        "id": 46493730,
-                    }
-                ],
-                "_status": "submitted_via_web",
-                "_geolocation": [36.97012, -122.0109429],
-                "_submission_time": "2021-11-16T23:46:27",
-                "_tags": [],
-                "_notes": [],
-                "_validation_status": {},
-                "_submitted_by": "cmi_admin_kobo_test",
-            },
-            {
-                "_id": 125283733,
-                "formhub/uuid": "f7bef041e8624f09946bff05ee5cbd4b",
-                "start": "2021-11-18T07:13:40.976-06:00",
-                "end": "2021-11-18T07:14:16.131-06:00",
-                "today": "2021-11-18",
-                "username": "iamjeffg",
-                "deviceid": "collect:LNnwswilWRvq6o6r",
-                "Record_your_current_location": "44.92933032 -93.22059967 230.54217529296875 5.36",
-                "Estimate_height_of_your_tree_in_meters": "4",
-                "I_like_this_tree_because": "beauty wildlife_habitat",
-                "Take_a_photo_of_this_tree": "1637241249813.jpg",
-                "__version__": "vLnrnT6Pvzgeh4DVfj6eDz",
-                "meta/instanceID": "uuid:5c408d9d-6a76-4fbb-bf4e-9ed8f8e3e382",
-                "_xform_id_string": form_id,
-                "_uuid": "5c408d9d-6a76-4fbb-bf4e-9ed8f8e3e382",
-                "_attachments": [
-                    {
-                        "download_url": f"{uri}/api/v2/assets/{form_id}/data/125283733/attachments/46632148/",
-                        "download_large_url": f"{uri}/api/v2/assets/{form_id}/data/125283733/attachments/46632148/",
-                        "download_medium_url": f"{uri}/api/v2/assets/{form_id}/data/125283733/attachments/46632148/",
-                        "download_small_url": f"{uri}/api/v2/assets/{form_id}/data/125283733/attachments/46632148/",
-                        "mimetype": "image/jpeg",
-                        "filename": "cmi_admin_kobo_test/attachments/f7bef041e8624f09946bff05ee5cbd4b/5c408d9d-6a76-4fbb-bf4e-9ed8f8e3e382/1637241249813.jpg",
-                        "instance": 125283733,
-                        "xform": 815328,
-                        "id": 46632148,
-                    }
-                ],
-                "_status": "submitted_via_web",
-                "_geolocation": [44.92933032, -93.22059967],
-                "_submission_time": "2021-11-18T13:14:26",
-                "_tags": [],
-                "_notes": [],
-                "_validation_status": {},
-                "_submitted_by": "iamjeffg",
-            },
-            {
-                "_id": 125340283,
-                "formhub/uuid": "f7bef041e8624f09946bff05ee5cbd4b",
-                "start": "2021-11-18T09:22:01.306-08:00",
-                "end": "2021-11-18T09:50:29.560-08:00",
-                "today": "2021-11-17",
-                "username": "afleishman",
-                "simserial": "simserial not found",
-                "deviceid": "ee.kobotoolbox.org:pSpP4Tnigrggt7BV",
-                "Record_your_current_location": "36.95751 -122.028192 17.47799301147461 10",
-                "Estimate_height_of_your_tree_in_meters": "24",
-                "I_like_this_tree_because": "shade wildlife_habitat beauty",
-                "Take_a_photo_of_this_tree": "74B37D46-A4D4-440B-8509-6817D83BAD64-9_23_38.jpeg",
-                "__version__": "vLnrnT6Pvzgeh4DVfj6eDz",
-                "meta/instanceID": "uuid:6a0e819b-9d89-4b59-bd1e-38355dd2e05f",
-                "meta/deprecatedID": "uuid:bf66ca42-160c-4207-8d01-af7df2852945",
-                "_xform_id_string": form_id,
-                "_uuid": "6a0e819b-9d89-4b59-bd1e-38355dd2e05f",
-                "_attachments": [
-                    {
-                        "download_url": f"{uri}/api/v2/assets/{form_id}/data/125340283/attachments/46653884/",
-                        "download_large_url": f"{uri}/api/v2/assets/{form_id}/data/125340283/attachments/46653884/",
-                        "download_medium_url": f"{uri}/api/v2/assets/{form_id}/data/125340283/attachments/46653884/",
-                        "download_small_url": f"{uri}/api/v2/assets/{form_id}/data/125340283/attachments/46653884/",
-                        "mimetype": "image/jpeg",
-                        "filename": "cmi_admin_kobo_test/attachments/f7bef041e8624f09946bff05ee5cbd4b/bf66ca42-160c-4207-8d01-af7df2852945/74B37D46-A4D4-440B-8509-6817D83BAD64-9_23_38.jpeg",
-                        "instance": 125340283,
-                        "xform": 815328,
-                        "id": 46653884,
-                    }
-                ],
-                "_status": "submitted_via_web",
-                "_geolocation": [36.95751, -122.028192],
-                "_submission_time": "2021-11-18T17:26:02",
-                "_tags": [],
-                "_notes": [],
-                "_validation_status": {},
-                "_submitted_by": "afleishman",
-            },
-        ]
+        {
+            "_id": 124961136,
+            "formhub/uuid": "f7bef041e8624f09946bff05ee5cbd4b",
+            "start": "2021-11-16T15:44:56.464-08:00",
+            "end": "2021-11-16T15:46:17.524-08:00",
+            "today": "2021-11-16",
+            "username": "cmi_admin_kobo_test",
+            "deviceid": "collect:pEo4VhQlQDnvDCNj",
+            "Record_your_current_location": "36.97012 -122.0109429 -14.432169171089349 4.969",
+            "Estimate_height_of_your_tree_in_meters": "18",
+            "I_like_this_tree_because": "shade food wildlife_habitat beauty",
+            "Take_a_photo_of_this_tree": "1637106370994.jpg",
+            "__version__": "vLnrnT6Pvzgeh4DVfj6eDz",
+            "meta/instanceID": "uuid:e58da38d-3eee-4bd7-8512-4a97ea8fbb01",
+            "_xform_id_string": form_id,
+            "_uuid": "e58da38d-3eee-4bd7-8512-4a97ea8fbb01",
+            "_attachments": [
+                {
+                    "download_url": f"{uri}/api/v2/assets/{form_id}/data/124961136/attachments/46493730/",
+                    "download_large_url": f"{uri}/api/v2/assets/{form_id}/data/124961136/attachments/46493730/",
+                    "download_medium_url": f"{uri}/api/v2/assets/{form_id}/data/124961136/attachments/46493730/",
+                    "download_small_url": f"{uri}/api/v2/assets/{form_id}/data/124961136/attachments/46493730/",
+                    "mimetype": "image/jpeg",
+                    "filename": "cmi_admin_kobo_test/attachments/f7bef041e8624f09946bff05ee5cbd4b/e58da38d-3eee-4bd7-8512-4a97ea8fbb01/1637106370994.jpg",
+                    "instance": 124961136,
+                    "xform": 815328,
+                    "id": 46493730,
+                }
+            ],
+            "_status": "submitted_via_web",
+            "_geolocation": [36.97012, -122.0109429],
+            "_submission_time": "2021-11-16T23:46:27",
+            "_tags": [],
+            "_notes": [],
+            "_validation_status": {},
+            "_submitted_by": "cmi_admin_kobo_test",
+        },
+        {
+            "_id": 125283733,
+            "formhub/uuid": "f7bef041e8624f09946bff05ee5cbd4b",
+            "start": "2021-11-18T07:13:40.976-06:00",
+            "end": "2021-11-18T07:14:16.131-06:00",
+            "today": "2021-11-18",
+            "username": "iamjeffg",
+            "deviceid": "collect:LNnwswilWRvq6o6r",
+            "Record_your_current_location": "44.92933032 -93.22059967 230.54217529296875 5.36",
+            "Estimate_height_of_your_tree_in_meters": "4",
+            "I_like_this_tree_because": "beauty wildlife_habitat",
+            "Take_a_photo_of_this_tree": "1637241249813.jpg",
+            "__version__": "vLnrnT6Pvzgeh4DVfj6eDz",
+            "meta/instanceID": "uuid:5c408d9d-6a76-4fbb-bf4e-9ed8f8e3e382",
+            "_xform_id_string": form_id,
+            "_uuid": "5c408d9d-6a76-4fbb-bf4e-9ed8f8e3e382",
+            "_attachments": [
+                {
+                    "download_url": f"{uri}/api/v2/assets/{form_id}/data/125283733/attachments/46632148/",
+                    "download_large_url": f"{uri}/api/v2/assets/{form_id}/data/125283733/attachments/46632148/",
+                    "download_medium_url": f"{uri}/api/v2/assets/{form_id}/data/125283733/attachments/46632148/",
+                    "download_small_url": f"{uri}/api/v2/assets/{form_id}/data/125283733/attachments/46632148/",
+                    "mimetype": "image/jpeg",
+                    "filename": "cmi_admin_kobo_test/attachments/f7bef041e8624f09946bff05ee5cbd4b/5c408d9d-6a76-4fbb-bf4e-9ed8f8e3e382/1637241249813.jpg",
+                    "instance": 125283733,
+                    "xform": 815328,
+                    "id": 46632148,
+                }
+            ],
+            "_status": "submitted_via_web",
+            "_geolocation": [44.92933032, -93.22059967],
+            "_submission_time": "2021-11-18T13:14:26",
+            "_tags": [],
+            "_notes": [],
+            "_validation_status": {},
+            "_submitted_by": "iamjeffg",
+        },
+        {
+            "_id": 125340283,
+            "formhub/uuid": "f7bef041e8624f09946bff05ee5cbd4b",
+            "start": "2021-11-18T09:22:01.306-08:00",
+            "end": "2021-11-18T09:50:29.560-08:00",
+            "today": "2021-11-17",
+            "username": "afleishman",
+            "simserial": "simserial not found",
+            "deviceid": "ee.kobotoolbox.org:pSpP4Tnigrggt7BV",
+            "Record_your_current_location": "36.95751 -122.028192 17.47799301147461 10",
+            "Estimate_height_of_your_tree_in_meters": "24",
+            "I_like_this_tree_because": "shade wildlife_habitat beauty",
+            "Take_a_photo_of_this_tree": "74B37D46-A4D4-440B-8509-6817D83BAD64-9_23_38.jpeg",
+            "__version__": "vLnrnT6Pvzgeh4DVfj6eDz",
+            "meta/instanceID": "uuid:6a0e819b-9d89-4b59-bd1e-38355dd2e05f",
+            "meta/deprecatedID": "uuid:bf66ca42-160c-4207-8d01-af7df2852945",
+            "_xform_id_string": form_id,
+            "_uuid": "6a0e819b-9d89-4b59-bd1e-38355dd2e05f",
+            "_attachments": [
+                {
+                    "download_url": f"{uri}/api/v2/assets/{form_id}/data/125340283/attachments/46653884/",
+                    "download_large_url": f"{uri}/api/v2/assets/{form_id}/data/125340283/attachments/46653884/",
+                    "download_medium_url": f"{uri}/api/v2/assets/{form_id}/data/125340283/attachments/46653884/",
+                    "download_small_url": f"{uri}/api/v2/assets/{form_id}/data/125340283/attachments/46653884/",
+                    "mimetype": "image/jpeg",
+                    "filename": "cmi_admin_kobo_test/attachments/f7bef041e8624f09946bff05ee5cbd4b/bf66ca42-160c-4207-8d01-af7df2852945/74B37D46-A4D4-440B-8509-6817D83BAD64-9_23_38.jpeg",
+                    "instance": 125340283,
+                    "xform": 815328,
+                    "id": 46653884,
+                }
+            ],
+            "_status": "submitted_via_web",
+            "_geolocation": [36.95751, -122.028192],
+            "_submission_time": "2021-11-18T17:26:02",
+            "_tags": [],
+            "_notes": [],
+            "_validation_status": {},
+            "_submitted_by": "afleishman",
+        },
+    ]
 
 
-def kobo_form_submissions(uri, form_id, limit=100, start=0):
-    """
-    Return paginated form submissions for testing.
-    
-    Parameters
-    ----------
-    uri : str
-        The base URI of the KoboToolbox server
-    form_id : str
-        The form ID
-    limit : int, optional
-        The maximum number of results to return per page (default: 100, matching API behavior as of January 2026)
-    start : int, optional
-        The starting index for pagination (default: 0)
-    
-    Returns
-    -------
-    dict
-        A paginated response with count, next, previous, and results
-    """
-    all_submissions = _get_all_submissions(uri, form_id)
+def kobo_form_nested(uri, form_id, form_name="Household Survey Fixture"):
+    """Form metadata with repeat groups and field-list groups for flattening tests."""
+    return {
+        "name": form_name,
+        "uid": form_id,
+        "owner__username": "fixture_user",
+        "data": posixpath.join(uri, "api/v2/assets", form_id, "data/"),
+        "content": {
+            "schema": "1",
+            "survey": [
+                {
+                    "name": "village_name",
+                    "type": "text",
+                    "label": ["Village name"],
+                    "$qpath": "village_name",
+                    "$xpath": "village_name",
+                    "$autoname": "village_name",
+                },
+                {
+                    "name": "interviewer_name",
+                    "type": "text",
+                    "label": ["Interviewer name"],
+                    "$qpath": "interviewer_name",
+                    "$xpath": "interviewer_name",
+                    "$autoname": "interviewer_name",
+                },
+                {
+                    "name": "household_members",
+                    "type": "begin_repeat",
+                    "label": ["Household members"],
+                    "$qpath": "household_members",
+                    "$xpath": "household_members",
+                    "$autoname": "household_members",
+                },
+                {
+                    "name": "group_fixture_member_1",
+                    "type": "begin_group",
+                    "label": ["Member"],
+                    "$qpath": "household_members/group_fixture_member_1",
+                    "$xpath": "household_members/group_fixture_member_1",
+                    "$autoname": "group_fixture_member_1",
+                },
+                {
+                    "name": "group_fixture_member_1_name",
+                    "type": "text",
+                    "label": ["Member name"],
+                    "$qpath": "household_members/group_fixture_member_1/group_fixture_member_1_name",
+                    "$xpath": "household_members/group_fixture_member_1/group_fixture_member_1_name",
+                    "$autoname": "group_fixture_member_1_name",
+                },
+                {
+                    "name": "group_fixture_member_1_age",
+                    "type": "integer",
+                    "label": ["Member age"],
+                    "$qpath": "household_members/group_fixture_member_1/group_fixture_member_1_age",
+                    "$xpath": "household_members/group_fixture_member_1/group_fixture_member_1_age",
+                    "$autoname": "group_fixture_member_1_age",
+                },
+                {"type": "end_group"},
+                {"type": "end_repeat"},
+                {
+                    "name": "dwelling_counts",
+                    "type": "begin_group",
+                    "label": ["Dwelling counts"],
+                    "$qpath": "dwelling_counts",
+                    "$xpath": "dwelling_counts",
+                    "$autoname": "dwelling_counts",
+                },
+                {
+                    "name": "group_fixture_house_adults",
+                    "type": "integer",
+                    "label": ["Adults"],
+                    "$qpath": "dwelling_counts/group_fixture_house/group_fixture_house_adults",
+                    "$xpath": "dwelling_counts/group_fixture_house/group_fixture_house_adults",
+                    "$autoname": "group_fixture_house_adults",
+                },
+                {
+                    "name": "group_fixture_house_children",
+                    "type": "integer",
+                    "label": ["Children"],
+                    "$qpath": "dwelling_counts/group_fixture_house/group_fixture_house_children",
+                    "$xpath": "dwelling_counts/group_fixture_house/group_fixture_house_children",
+                    "$autoname": "group_fixture_house_children",
+                },
+                {"type": "end_group"},
+            ],
+            "choices": [],
+            "settings": {"version": "1", "default_language": "English (en)"},
+            "translated": ["label"],
+            "translations": [None],
+        },
+    }
+
+
+def _get_nested_submissions(uri, form_id):
+    """Return synthetic submissions with repeat groups and field-list dicts."""
+    return [
+        {
+            "_id": 900001,
+            "formhub/uuid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "village_name": "Village Alpha",
+            "interviewer_name": "Interviewer A",
+            "household_members": [
+                {
+                    "household_members/group_fixture_member_1/group_fixture_member_1_name": "Person One",
+                    "household_members/group_fixture_member_1/group_fixture_member_1_age": "25",
+                },
+                {
+                    "household_members/group_fixture_member_1/group_fixture_member_1_name": "Person Two",
+                    "household_members/group_fixture_member_1/group_fixture_member_1_age": "30",
+                },
+            ],
+            "summary_counts/adults": "2",
+            "__version__": "fixtureVersion01",
+            "meta/instanceID": "uuid:11111111-1111-1111-1111-111111111111",
+            "_xform_id_string": form_id,
+            "_uuid": "11111111-1111-1111-1111-111111111111",
+            "_attachments": [],
+            "_status": "submitted_via_web",
+            "_geolocation": [10.0, 20.0],
+            "_submission_time": "2026-01-15T10:00:00",
+            "_tags": [],
+            "_notes": [],
+            "_validation_status": {},
+            "_submitted_by": "fixture_user",
+        },
+        {
+            "_id": 900002,
+            "formhub/uuid": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "village_name": "Village Beta",
+            "interviewer_name": "Interviewer B",
+            "household_members": [
+                {
+                    "household_members/group_fixture_member_1/group_fixture_member_1_name": "Person Three",
+                    "household_members/group_fixture_member_1/group_fixture_member_1_age": "40",
+                },
+            ],
+            "dwelling_counts": {
+                "dwelling_counts/group_fixture_house/group_fixture_house_adults": "2",
+                "dwelling_counts/group_fixture_house/group_fixture_house_children": "1",
+            },
+            "__version__": "fixtureVersion01",
+            "meta/instanceID": "uuid:22222222-2222-2222-2222-222222222222",
+            "_xform_id_string": form_id,
+            "_uuid": "22222222-2222-2222-2222-222222222222",
+            "_attachments": [],
+            "_status": "submitted_via_web",
+            "_submission_time": "2026-01-15T11:00:00",
+            "_tags": [],
+            "_notes": [],
+            "_validation_status": {},
+            "_submitted_by": "fixture_user",
+        },
+        {
+            "_id": 900003,
+            "formhub/uuid": "cccccccccccccccccccccccccccccccc",
+            "village_name": "Village Gamma",
+            "interviewer_name": "Interviewer C",
+            # Repeat group nested inside another repeat group.
+            "first_group": [
+                {
+                    "first_group/second_group": [
+                        {
+                            "first_group/second_group/group_er3uf83_row/group_er3uf83_row_column": "John",
+                            "first_group/second_group/group_er3uf83_row/group_er3uf83_row_second_column": "Doe",
+                        },
+                        {
+                            "first_group/second_group/group_er3uf83_row/group_er3uf83_row_column": "Jane",
+                            "first_group/second_group/group_er3uf83_row/group_er3uf83_row_second_column": "Doe",
+                        },
+                    ]
+                },
+            ],
+            "__version__": "fixtureVersion01",
+            "meta/instanceID": "uuid:33333333-3333-3333-3333-333333333333",
+            "_xform_id_string": form_id,
+            "_uuid": "33333333-3333-3333-3333-333333333333",
+            "_attachments": [],
+            "_status": "submitted_via_web",
+            "_submission_time": "2026-01-15T12:00:00",
+            "_tags": [],
+            "_notes": [],
+            "_validation_status": {},
+            "_submitted_by": "fixture_user",
+        },
+    ]
+
+
+def _paginate_submissions(uri, form_id, all_submissions, limit=100, start=0):
     total_count = len(all_submissions)
-    
-    # Paginate results
     end = start + limit
     results = all_submissions[start:end]
-    
-    # Build next URL if there are more results
+
     next_url = None
     if end < total_count:
         next_params = {"limit": limit, "start": end}
         next_url = f"{uri}/api/v2/assets/{form_id}/data/?{urlencode(next_params)}"
-    
-    # Build previous URL if we're not on the first page
+
     previous_url = None
     if start > 0:
         prev_start = max(0, start - limit)
         prev_params = {"limit": limit, "start": prev_start}
         previous_url = f"{uri}/api/v2/assets/{form_id}/data/?{urlencode(prev_params)}"
-    
+
     return {
         "count": total_count,
         "next": next_url,
         "previous": previous_url,
         "results": results,
     }
+
+
+def kobo_form_submissions(uri, form_id, limit=100, start=0):
+    """Return paginated form submissions for testing"""
+    return _paginate_submissions(
+        uri, form_id, _get_all_submissions(uri, form_id), limit, start
+    )
+
+
+def kobo_nested_form_submissions(uri, form_id, limit=100, start=0):
+    """Return paginated nested-form submissions for flattening tests."""
+    return _paginate_submissions(
+        uri, form_id, _get_nested_submissions(uri, form_id), limit, start
+    )

--- a/f/connectors/kobotoolbox/tests/conftest.py
+++ b/f/connectors/kobotoolbox/tests/conftest.py
@@ -22,19 +22,35 @@ def mocked_responses():
 def _paginated_data_callback(request):
     """Callback to handle paginated data requests with query parameters."""
     import urllib.parse
-    
+
     # Parse query parameters from the request
     parsed_url = urllib.parse.urlparse(request.url)
     query_params = urllib.parse.parse_qs(parsed_url.query)
-    
+
     # Default to 100 if limit not specified, matching API behavior as of January 2026
     limit = int(query_params.get("limit", [100])[0])
     start = int(query_params.get("start", [0])[0])
-    
+
     response_data = server_responses.kobo_form_submissions(
         server_url, form_id, limit=limit, start=start
     )
-    
+
+    return (200, {}, json.dumps(response_data))
+
+
+def _paginated_nested_data_callback(request):
+    """Paginated data callback for the nested repeat-group fixture form."""
+    import urllib.parse
+
+    parsed_url = urllib.parse.urlparse(request.url)
+    query_params = urllib.parse.parse_qs(parsed_url.query)
+    limit = int(query_params.get("limit", [100])[0])
+    start = int(query_params.get("start", [0])[0])
+
+    response_data = server_responses.kobo_nested_form_submissions(
+        server_url, server_responses.nested_form_id, limit=limit, start=start
+    )
+
     return (200, {}, json.dumps(response_data))
 
 
@@ -110,10 +126,39 @@ def koboserver_no_submissions(mocked_responses):
 def koboserver_with_pagination(mocked_responses):
     """Fixture with many submissions to test pagination (3 pages with limit=1)."""
     metadata = server_responses.kobo_form(server_url, form_id, form_name)
-    
+
     _register_common_mocks(mocked_responses, form_id, metadata)
-    
+
     return _build_koboserver_fixture(metadata)
+
+
+@pytest.fixture
+def koboserver_nested(mocked_responses):
+    """Fixture with repeat groups and field-list dict payloads for flattening tests."""
+    nested_id = server_responses.nested_form_id
+    metadata = server_responses.kobo_form_nested(server_url, nested_id)
+
+    mocked_responses.get(
+        f"{server_url}/api/v2/assets/{nested_id}/",
+        json=metadata,
+        status=200,
+    )
+    mocked_responses.add_callback(
+        responses.GET,
+        re.compile(rf"{server_url}/api/v2/assets/{nested_id}/data/"),
+        callback=_paginated_nested_data_callback,
+        content_type="application/json",
+    )
+
+    @dataclass
+    class KoboServer:
+        account: dict
+        form_id: str
+
+    return KoboServer(
+        dict(server_url=server_url, api_key="Callooh!Callay!"),
+        nested_id,
+    )
 
 
 @pytest.fixture

--- a/f/connectors/kobotoolbox/tests/conftest.py
+++ b/f/connectors/kobotoolbox/tests/conftest.py
@@ -87,6 +87,26 @@ def koboserver_no_translations(mocked_responses):
 
 
 @pytest.fixture
+def koboserver_no_submissions(mocked_responses):
+    """Fixture whose form has valid metadata but zero submissions."""
+    metadata = server_responses.kobo_form(server_url, form_id, form_name)
+
+    mocked_responses.get(
+        f"{server_url}/api/v2/assets/{form_id}/",
+        json=metadata,
+        status=200,
+    )
+    mocked_responses.add(
+        responses.GET,
+        re.compile(rf"{server_url}/api/v2/assets/{form_id}/data/"),
+        json={"count": 0, "next": None, "previous": None, "results": []},
+        status=200,
+    )
+
+    return _build_koboserver_fixture(metadata)
+
+
+@pytest.fixture
 def koboserver_with_pagination(mocked_responses):
     """Fixture with many submissions to test pagination (3 pages with limit=1)."""
     metadata = server_responses.kobo_form(server_url, form_id, form_name)

--- a/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
+++ b/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import psycopg
 
 from f.connectors.kobotoolbox.kobotoolbox_responses import (
+    flatten_kobotoolbox_submission,
     main,
     transform_kobotoolbox_form_data,
 )
@@ -233,3 +234,147 @@ def test_pagination(koboserver_with_pagination, pg_database, tmp_path):
             assert "124961136" in ids
             assert "125283733" in ids
             assert "125340283" in ids
+
+
+def test_flatten_kobotoolbox_submission__repeat_group():
+    submission = {
+        "household_members": [
+            {
+                "household_members/group_fixture_member_1/group_fixture_member_1_name": "Person One",
+                "household_members/group_fixture_member_1/group_fixture_member_1_age": "25",
+            },
+            {
+                "household_members/group_fixture_member_1/group_fixture_member_1_name": "Person Two",
+                "household_members/group_fixture_member_1/group_fixture_member_1_age": "30",
+            },
+        ],
+    }
+    result = flatten_kobotoolbox_submission(submission)
+
+    assert "household_members" not in result
+    assert result["household_members/1/group_fixture_member_1_name"] == "Person One"
+    assert result["household_members/1/group_fixture_member_1_age"] == "25"
+    assert result["household_members/2/group_fixture_member_1_name"] == "Person Two"
+    assert result["household_members/2/group_fixture_member_1_age"] == "30"
+
+
+def test_flatten_kobotoolbox_submission__field_list_dict():
+    submission = {
+        "dwelling_counts": {
+            "dwelling_counts/group_fixture_house/group_fixture_house_adults": "2",
+            "dwelling_counts/group_fixture_house/group_fixture_house_children": "1",
+        },
+    }
+    result = flatten_kobotoolbox_submission(submission)
+
+    assert "dwelling_counts" not in result
+    assert result["dwelling_counts/1/group_fixture_house_adults"] == "2"
+    assert result["dwelling_counts/1/group_fixture_house_children"] == "1"
+
+
+def test_flatten_kobotoolbox_submission__preserves_system_fields():
+    submission = {
+        "_id": 1,
+        "_geolocation": [10.0, 20.0],
+        "_attachments": [
+            {"download_url": "http://example.org/file.jpg", "filename": "file.jpg"}
+        ],
+        "_validation_status": {},
+        "_tags": [],
+        "summary_counts/adults": "2",
+        "household_members": [],
+    }
+    result = flatten_kobotoolbox_submission(submission)
+
+    assert result["_id"] == 1
+    assert result["_geolocation"] == [10.0, 20.0]
+    assert result["_attachments"] == submission["_attachments"]
+    assert result["_validation_status"] == {}
+    assert result["_tags"] == []
+    assert result["summary_counts/adults"] == "2"
+    assert result["household_members"] == []
+
+
+def test_flatten_kobotoolbox_submission__deeply_nested_repeat():
+    """A repeat group nested inside another repeat group must flatten all the way down.
+
+    Kobo emits the inner repeat as a slash-keyed ``list[dict]`` under each outer
+    row, so the flattener has to recurse instead of leaving the inner list as a
+    JSON blob under ``first_group/{i}/second_group``.
+    """
+    submission = {
+        "first_group": [
+            {
+                "first_group/second_group": [
+                    {
+                        "first_group/second_group/group_er3uf83_row/group_er3uf83_row_column": "John",
+                        "first_group/second_group/group_er3uf83_row/group_er3uf83_row_second_column": "Doe",
+                    },
+                    {
+                        "first_group/second_group/group_er3uf83_row/group_er3uf83_row_column": "Jane",
+                        "first_group/second_group/group_er3uf83_row/group_er3uf83_row_second_column": "Doe",
+                    },
+                ]
+            },
+            {
+                "first_group/second_group": [
+                    {
+                        "first_group/second_group/group_er3uf83_row/group_er3uf83_row_column": "Foo",
+                        "first_group/second_group/group_er3uf83_row/group_er3uf83_row_second_column": "Bar",
+                    },
+                ]
+            },
+        ],
+    }
+    result = flatten_kobotoolbox_submission(submission)
+
+    assert "first_group" not in result
+    # Nothing should remain as a nested container once fully flattened.
+    assert not any(isinstance(v, (list, dict)) for v in result.values())
+    assert result["first_group/1/second_group/1/group_er3uf83_row_column"] == "John"
+    assert result["first_group/1/second_group/2/group_er3uf83_row_column"] == "Jane"
+    assert (
+        result["first_group/1/second_group/2/group_er3uf83_row_second_column"] == "Doe"
+    )
+    assert result["first_group/2/second_group/1/group_er3uf83_row_column"] == "Foo"
+    assert (
+        result["first_group/2/second_group/1/group_er3uf83_row_second_column"] == "Bar"
+    )
+
+
+def test_script_e2e__nested_repeats(koboserver_nested, pg_database, tmp_path):
+    asset_storage = tmp_path / "datalake"
+    table_name = "kobo_nested_repeats"
+
+    main(
+        koboserver_nested.account,
+        koboserver_nested.form_id,
+        pg_database,
+        table_name,
+        asset_storage,
+    )
+
+    with psycopg.connect(autocommit=True, **pg_database) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+            assert cursor.fetchone()[0] == 3
+
+            cursor.execute(
+                f'SELECT "group_fixture_member_1_name__1__household_members" '
+                f"FROM {table_name} WHERE _id = '900001'"
+            )
+            assert cursor.fetchone()[0] == "Person One"
+
+            cursor.execute(
+                f'SELECT "group_fixture_house_adults__1__dwelling_counts" '
+                f"FROM {table_name} WHERE _id = '900002'"
+            )
+            assert cursor.fetchone()[0] == "2"
+
+            # A repeat nested inside a repeat is flattened all the way down, so
+            # even the innermost leaf lands in its own reversed/underscored column.
+            cursor.execute(
+                f'SELECT "group_er3uf83_row_column__2__second_group__1__first_group" '
+                f"FROM {table_name} WHERE _id = '900003'"
+            )
+            assert cursor.fetchone()[0] == "Jane"

--- a/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
+++ b/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
@@ -32,6 +32,10 @@ def test_script_e2e(koboserver, pg_database, tmp_path):
         key in metadata for key in ["name", "uid", "owner__username", "data", "content"]
     )
 
+    # CSV artifact is also saved to disk
+    csv_file = asset_storage / table_name / f"{table_name}.csv"
+    assert csv_file.exists()
+
     # Survey responses are written to a SQL Table
     with psycopg.connect(autocommit=True, **pg_database) as conn:
         with conn.cursor() as cursor:

--- a/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
+++ b/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
@@ -161,6 +161,33 @@ def test_script_e2e__no_translations(koboserver_no_translations, pg_database, tm
             assert cursor.fetchone() == ("Record your current location",)
 
 
+def test_script_e2e__no_submissions(koboserver_no_submissions, pg_database, tmp_path):
+    asset_storage = tmp_path / "datalake"
+    table_name = "kobo_no_submissions"
+
+    # A zero-submission pull must not raise
+    main(
+        koboserver_no_submissions.account,
+        koboserver_no_submissions.form_id,
+        pg_database,
+        table_name,
+        asset_storage,
+    )
+
+    # No CSV artifact is written when there are no submissions
+    assert not (asset_storage / table_name / f"{table_name}.csv").exists()
+
+    with psycopg.connect(autocommit=True, **pg_database) as conn:
+        with conn.cursor() as cursor:
+            # No response table is created
+            cursor.execute("SELECT to_regclass(%s)", (f"public.{table_name}",))
+            assert cursor.fetchone()[0] is None
+
+            # Labels are still written even when there are no submissions
+            cursor.execute(f"SELECT COUNT(*) FROM {table_name}__labels")
+            assert cursor.fetchone()[0] == 24
+
+
 def test_transform_kobotoolbox_form_data_from_csv():
     csv_path = Path(__file__).parent / "assets" / "kobotoolbox_submissions.csv"
     with csv_path.open(newline="", encoding="utf-8") as f:

--- a/f/connectors/odk/odk_responses.py
+++ b/f/connectors/odk/odk_responses.py
@@ -274,6 +274,8 @@ def transform_odk_form_data(form_data, form_name=None):
     list
         A list of transformed form submissions with added metadata fields and formatted geometry.
     """
+    # TODO: ODK repeat groups / matrix payloads are not flattened yet. See the
+    # KoboToolbox connector and README.md for details on how it is handled there.
     for submission in form_data:
         # Add metadata fields
         # Handle both API format (__id) and CSV format (KEY)

--- a/f/connectors/odk/odk_responses.py
+++ b/f/connectors/odk/odk_responses.py
@@ -79,27 +79,32 @@ def main(
         transformed_form_data = transform_odk_form_data(form_data, form_name=form_id)
 
         save_path = Path(attachment_root) / db_table_name
-        save_data_to_file(
-            transformed_form_data,
-            db_table_name,
-            save_path,
-            file_type="csv",
-        )
+        if transformed_form_data:
+            save_data_to_file(
+                transformed_form_data,
+                db_table_name,
+                save_path,
+                file_type="csv",
+            )
 
-        save_csv_to_postgres(
-            db,
-            db_table_name,
-            str(Path(db_table_name) / f"{db_table_name}.csv"),
-            attachment_root,
-            delete_csv_file=False,
-            id_column="_id",
-            use_mapping_table=True,
-            reverse_properties_separated_by="/",
-        )
+            save_csv_to_postgres(
+                db,
+                db_table_name,
+                str(Path(db_table_name) / f"{db_table_name}.csv"),
+                attachment_root,
+                delete_csv_file=False,
+                id_column="_id",
+                use_mapping_table=True,
+                reverse_properties_separated_by="/",
+            )
 
-        logger.info(
-            f"ODK responses successfully written to database table: [{db_table_name}]"
-        )
+            logger.info(
+                f"ODK responses successfully written to database table: [{db_table_name}]"
+            )
+        else:
+            logger.warning(
+                f"No submissions returned; skipping database write for table: [{db_table_name}]"
+            )
 
     finally:
         config_path.unlink(missing_ok=True)

--- a/f/connectors/odk/odk_responses.py
+++ b/f/connectors/odk/odk_responses.py
@@ -10,7 +10,9 @@ from typing import TypedDict
 
 from pyodk.client import Client
 
-from f.common_logic.db_operations import StructuredDBWriter, conninfo, postgresql
+from f.common_logic.db_operations import postgresql
+from f.common_logic.file_operations import save_data_to_file
+from f.connectors.csv.csv_to_postgres import main as save_csv_to_postgres
 
 
 # https://hub.windmill.dev/resource_types/272/odk_config
@@ -76,13 +78,24 @@ def main(
 
         transformed_form_data = transform_odk_form_data(form_data, form_name=form_id)
 
-        db_writer = StructuredDBWriter(
-            conninfo(db),
+        save_path = Path(attachment_root) / db_table_name
+        save_data_to_file(
+            transformed_form_data,
             db_table_name,
+            save_path,
+            file_type="csv",
+        )
+
+        save_csv_to_postgres(
+            db,
+            db_table_name,
+            str(Path(db_table_name) / f"{db_table_name}.csv"),
+            attachment_root,
+            delete_csv_file=False,
+            id_column="_id",
             use_mapping_table=True,
             reverse_properties_separated_by="/",
         )
-        db_writer.handle_output(transformed_form_data)
 
         logger.info(
             f"ODK responses successfully written to database table: [{db_table_name}]"

--- a/f/connectors/odk/tests/conftest.py
+++ b/f/connectors/odk/tests/conftest.py
@@ -81,6 +81,41 @@ def odkserver(mocked_responses):
 
 
 @pytest.fixture
+def odkserver_no_submissions(mocked_responses):
+    """A mock ODK Server whose form returns zero submissions."""
+
+    @dataclass
+    class OdkServer:
+        config: dict
+        form_id: str
+
+    base_url = "http://odk.example.org"
+    default_project_id = "1"
+    form_id = "My_monitoring_form"
+
+    mocked_responses.post(
+        f"{base_url}/v1/sessions",
+        json={"token": "mocked_token"},
+        status=200,
+    )
+    mocked_responses.get(
+        f"{base_url}/v1/projects/{default_project_id}/forms/{form_id}.svc/Submissions",
+        json={"value": []},
+        status=200,
+    )
+
+    return OdkServer(
+        dict(
+            base_url=base_url,
+            username="collector",
+            password="GathererOfData",
+            default_project_id=default_project_id,
+        ),
+        form_id,
+    )
+
+
+@pytest.fixture
 def pg_database():
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
     db = testing.postgresql.Postgresql(port=7654)

--- a/f/connectors/odk/tests/conftest.py
+++ b/f/connectors/odk/tests/conftest.py
@@ -8,6 +8,18 @@ import responses
 import testing.postgresql
 
 
+@pytest.fixture(autouse=True)
+def _isolate_pyodk_cache(monkeypatch, tmp_path):
+    """Give each test its own empty pyODK token cache.
+
+    By default pyODK caches its session token in ~/.pyodk_cache.toml, so a token
+    written by one test leaks into the next and triggers a token-verification
+    request (GET /v1/users/current) that the mock server doesn't expect. Pointing
+    the cache at a fresh temp file per test keeps every test on the login path.
+    """
+    monkeypatch.setenv("PYODK_CACHE_FILE", str(tmp_path / "pyodk_cache.toml"))
+
+
 @pytest.fixture
 def mocked_responses():
     """responses.RequestsMock context, for testing code that makes HTTP requests."""

--- a/f/connectors/odk/tests/odk_responses_test.py
+++ b/f/connectors/odk/tests/odk_responses_test.py
@@ -21,6 +21,10 @@ def test_script_e2e(odkserver, pg_database, tmp_path):
     # Attachments are saved to disk
     assert (asset_storage / table_name / "attachments" / "1739327186781.m4a").exists()
 
+    # CSV artifact is also saved to disk
+    csv_file = asset_storage / table_name / f"{table_name}.csv"
+    assert csv_file.exists()
+
     # Survey responses are written to a SQL Table
     with psycopg.connect(autocommit=True, **pg_database) as conn:
         with conn.cursor() as cursor:

--- a/f/connectors/odk/tests/odk_responses_test.py
+++ b/f/connectors/odk/tests/odk_responses_test.py
@@ -44,6 +44,29 @@ def test_script_e2e(odkserver, pg_database, tmp_path):
             assert cursor.fetchone() is not None
 
 
+def test_script_e2e__no_submissions(odkserver_no_submissions, pg_database, tmp_path):
+    asset_storage = tmp_path / "datalake"
+    table_name = "odk_no_submissions"
+
+    # A zero-submission pull must not raise
+    main(
+        odkserver_no_submissions.config,
+        odkserver_no_submissions.form_id,
+        pg_database,
+        table_name,
+        asset_storage,
+    )
+
+    # No CSV artifact is written when there are no submissions
+    assert not (asset_storage / table_name / f"{table_name}.csv").exists()
+
+    # No response table is created
+    with psycopg.connect(autocommit=True, **pg_database) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT to_regclass(%s)", (f"public.{table_name}",))
+            assert cursor.fetchone()[0] is None
+
+
 def test_transform_odk_form_data_from_csv():
     csv_path = Path(__file__).parent / "assets" / "submissions.csv"
     with csv_path.open(newline="", encoding="utf-8") as f:


### PR DESCRIPTION
## Goal

One of the things we are discovering that people really like about Guardian Connector is the ability to use Filebrowser to download an ingested file version of a dataset. We currently do this for spatial datasets -- that is, when, say, the CoMapeo script is run, in addition to writing to Postgres it also saves a GeoJSON to disk. And our users have found value in then logging into Filebrowser to download the GeoJSON file for usage in QGIS or other third party tools.

Recently, a use case came up to also do the same for non-spatial datasets, like a KoboToolbox survey. One of our partners is building a survey with nested groups, and the way we handle those in the KoboToolbox script actually produces a more useful tabular dataset than what you get by downloading the data from KoboToolbox itself. So, we would like to make the CSV available on disk, much like we do for GeoJSON files.

In doing so, I thought it would also be good to harden CSV serialization so exported datasets preserve nested structures and handle missing values consistently.

## What I changed and why

1. Updates `save_data_to_file` so CSV exports can be generated directly from structured records. We now supports a list of dictionaries, builds a header row, keeps `_id` first when present, JSON-encodes nested lists/dicts, and writes missing/None values as empty cells so the CSV can round-trip cleanly back into Postgres.
2. Has all the survey tools (Kobo, ODK, EpiCollect) saving the file as CSV to disk.

## How I convinced myself this is right

- Justification for why this is right in **Goal**
- Trying it out in runtime (inspecting a few actual CSVs generated)
- Our whole test suite passing

## What I'm not doing here

I thought twice about whether `csv_to_postgres` should handle the saving to disk, so we don't need to do that in every connector. But I decided against it (for now) because `geojson_to_postgres` also doesn't handle this, so I preferred to be consistent.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

I had Cursor generate the docstrings (which I then further simplified as they were overly verbose) and the tests were also heavily auto-complete written. 