### PR TITLE
Flatten KoboToolbox matrix and repeat-group responses

### DIFF
--- a/f/connectors/kobotoolbox/README.md
+++ b/f/connectors/kobotoolbox/README.md
@@ -52,7 +52,7 @@ dwelling_counts/1/house_children = "1"
 
 The existing `reverse_properties_separated_by="/"` logic then reverses each key into a SQL column, e.g. `household_members/1/member_name` → `member_name__1__household_members`.
 
-> **Note:** The ODK connector (`f/connectors/odk/odk_responses.py`) shares this plumbing but does **not** yet flatten nested payloads. See the `TODO` there.
+> **Note:** The ODK connector (`f/connectors/odk/odk_responses.py`) shares this XLSForm-style plumbing but does not (yet) flatten nested payloads. See the `TODO` there.
 
 ## 📚 Reference
 

--- a/f/connectors/kobotoolbox/README.md
+++ b/f/connectors/kobotoolbox/README.md
@@ -18,6 +18,42 @@ Each row represents one label for a form element (from either the `survey` or `c
 
 This table can be used for rendering field translations in downstream clients, selecting the appropriate label by language, or falling back gracefully when a translation is missing.
 
+## Nested Data Flattening (repeat groups & matrices)
+
+KoboToolbox returns [repeat groups](https://support.kobotoolbox.org/group_repeat.html) and [matrix](https://support.kobotoolbox.org/matrix_response.html) questions as **lists of dicts** with long slash-separated keys. Left alone, each of these lands in a single cell that is difficult to analyze in downstream tools like Apache Superset. Before insertion, submissions are flattened into wide `{group}/{index}/{leaf}` keys (1-based index, `leaf` = last slash segment).
+
+A repeat group from the API:
+
+```json
+"household_members": [
+  { "household_members/member/member_name": "Ada",  "household_members/member/member_age": "40" },
+  { "household_members/member/member_name": "Alan", "household_members/member/member_age": "37" }
+]
+```
+
+is flattened to:
+
+```
+household_members/1/member_name = "Ada"
+household_members/1/member_age  = "40"
+household_members/2/member_name = "Alan"
+household_members/2/member_age  = "37"
+```
+
+A field-list group arrives as a lone dict and is flattened with index `1`:
+
+```json
+"dwelling_counts": { "dwelling_counts/house/house_adults": "2", "dwelling_counts/house/house_children": "1" }
+```
+```
+dwelling_counts/1/house_adults   = "2"
+dwelling_counts/1/house_children = "1"
+```
+
+The existing `reverse_properties_separated_by="/"` logic then reverses each key into a SQL column, e.g. `household_members/1/member_name` → `member_name__1__household_members`.
+
+> **Note:** The ODK connector (`f/connectors/odk/odk_responses.py`) shares this plumbing but does **not** yet flatten nested payloads. See the `TODO` there.
+
 ## 📚 Reference
 
 * KoboToolbox API Documentation: https://support.kobotoolbox.org/api.html

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -342,8 +342,8 @@ def download_form_responses_and_attachments(
     return form_submissions, form_name, form_languages
 
 
-# TODO - YAGNI: Extract to f/common_logic/submission_flatten.py if/when ODK repeat/matrix
-# flattening lands; not worth a common module until then.
+# TODO - YAGNI: Extract to f/common_logic/submission_flatten.py if/when ODK
+# flattening is required; not worth a common module until then.
 def _slash_keyed_rows(value):
     """Return the repeat/field-list rows to flatten, or ``None`` to keep as-is.
 

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -395,6 +395,9 @@ def flatten_kobotoolbox_submission(submission):
     slash-separated keys. Field-list groups may arrive as a lone ``dict`` with
     slash keys. Both are expanded to ``{group}/{index}/{leaf_key}`` (1-based index).
 
+    Repeat groups can be nested (a repeat inside a repeat), so flattening recurses
+    until no slash-keyed rows remain, e.g. ``{outer}/{i}/{inner}/{j}/{leaf_key}``.
+
     Parameters
     ----------
     submission : dict
@@ -410,11 +413,21 @@ def flatten_kobotoolbox_submission(submission):
         rows = _get_flattenable_kobo_rows(value)
         if rows is None:
             flat[key] = value
-            continue
-        for index, item in enumerate(rows, start=1):
-            for slash_key, field_value in item.items():
-                flat[f"{key}/{index}/{slash_key.rsplit('/', 1)[-1]}"] = field_value
+        else:
+            _flatten_kobo_rows(key, rows, flat)
     return flat
+
+
+def _flatten_kobo_rows(prefix, rows, flat):
+    """Expand ``rows`` under ``prefix`` into ``flat``, recursing into nested repeats."""
+    for index, row in enumerate(rows, start=1):
+        for slash_key, value in row.items():
+            key = f"{prefix}/{index}/{slash_key.rsplit('/', 1)[-1]}"
+            nested = _get_flattenable_kobo_rows(value)
+            if nested is None:
+                flat[key] = value
+            else:
+                _flatten_kobo_rows(key, nested, flat)
 
 
 def transform_kobotoolbox_form_data(form_data, form_name=None, form_languages=None):

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -342,6 +342,71 @@ def download_form_responses_and_attachments(
     return form_submissions, form_name, form_languages
 
 
+# TODO -YAGNI: Extract to f/common_logic/submission_flatten.py if/when ODK repeat/matrix
+# flattening lands; not worth a common module until then.
+def _slash_keyed_rows(value):
+    """Return the repeat/field-list rows to flatten, or ``None`` to keep as-is.
+
+    Kobo emits repeat groups and matrices as a ``list[dict]`` (each row carrying
+    at least one slash-separated key) and field-list groups as a lone ``dict``
+    whose keys are all slash-separated. Scalars, ``_geolocation``,
+    ``_attachments`` and empty containers return ``None`` and pass through.
+    """
+    # Repeat group / matrix: list of row dicts, e.g.
+    #   household_members: [{ "household_members/member/name": "Ada", ... }, ...]
+    # Require every row to be a dict with at least one slash key so we do not
+    # mis-treat plain lists (_tags, _attachments metadata, empty repeats).
+    if (
+        isinstance(value, list)
+        and value
+        and all(isinstance(item, dict) for item in value)
+        and all(any(isinstance(k, str) and "/" in k for k in item) for item in value)
+    ):
+        return value
+
+    # Field-list group: single dict of slash keys, no repeat index in the payload.
+    # Wrap as a one-row list so the same flatten loop handles both shapes.
+    # Requiring "/" on every key excludes system dicts (_validation_status, etc.).
+    if (
+        isinstance(value, dict)
+        and value
+        and all(isinstance(k, str) and "/" in k for k in value)
+    ):
+        return [value]
+
+    # Scalars, empty containers, geolocation, attachments, and anything else.
+    return None
+
+
+def flatten_kobotoolbox_submission(submission):
+    """Flatten Kobo repeat-group and field-list payloads into wide slash-separated keys.
+
+    Repeat groups and matrix questions arrive as ``list[dict]`` values with long
+    slash-separated keys. Field-list groups may arrive as a lone ``dict`` with
+    slash keys. Both are expanded to ``{group}/{index}/{leaf_key}`` (1-based index).
+
+    Parameters
+    ----------
+    submission : dict
+        A single KoboToolbox submission record.
+
+    Returns
+    -------
+    dict
+        A flattened copy of the submission with repeat/field-list blobs expanded.
+    """
+    flat = {}
+    for key, value in submission.items():
+        rows = _slash_keyed_rows(value)
+        if rows is None:
+            flat[key] = value
+            continue
+        for index, item in enumerate(rows, start=1):
+            for slash_key, field_value in item.items():
+                flat[f"{key}/{index}/{slash_key.rsplit('/', 1)[-1]}"] = field_value
+    return flat
+
+
 def transform_kobotoolbox_form_data(form_data, form_name=None, form_languages=None):
     """Transform KoboToolbox form data by adding metadata fields and formatting geometry for SQL database insertion.
 
@@ -359,7 +424,9 @@ def transform_kobotoolbox_form_data(form_data, form_name=None, form_languages=No
     list
         A list of transformed form submissions with added metadata fields and formatted geometry.
     """
-    for submission in form_data:
+    for i, submission in enumerate(form_data):
+        submission = flatten_kobotoolbox_submission(submission)
+        form_data[i] = submission
         # Add metadata fields if provided
         if form_name:
             submission["dataset_name"] = form_name

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -344,17 +344,29 @@ def download_form_responses_and_attachments(
 
 # TODO - YAGNI: Extract to f/common_logic/submission_flatten.py if/when ODK
 # flattening is required; not worth a common module until then.
-def _slash_keyed_rows(value):
-    """Return the repeat/field-list rows to flatten, or ``None`` to keep as-is.
+def _get_flattenable_kobo_rows(value):
+    """Return a Kobo field value as a list of rows to flatten, or ``None`` to leave it alone.
 
-    Kobo emits repeat groups and matrices as a ``list[dict]`` (each row carrying
-    at least one slash-separated key) and field-list groups as a lone ``dict``
-    whose keys are all slash-separated.
+    We only flatten values that look like a group of fields with slash-separated
+    keys. There are two such shapes:
+
+    A list of row dicts (repeat group / matrix), e.g.::
+
+        [
+            {"household_members/name": "Ada", ...},
+            {"household_members/name": "Bo",  ...},
+        ]
+
+    A single dict of slash keys (field-list group), e.g.::
+
+        {"location/lat": 1.0, "location/lng": 2.0}
+
+    Both are returned as a list of rows. Everything else (scalars, empty
+    containers, geolocation, attachments, and system lists/dicts like ``_tags``
+    or ``_validation_status``) returns ``None`` and is kept as-is.
     """
-    # Repeat group / matrix: list of row dicts, e.g.
-    #   household_members: [{ "household_members/member/name": "Ada", ... }, ...]
-    # Require every row to be a dict with at least one slash key so we do not
-    # mis-treat plain lists (_tags, _attachments metadata, empty repeats).
+    # Every row must be a dict with at least one slash key. This excludes plain
+    # lists such as _tags, _attachments metadata, and empty repeats.
     if (
         isinstance(value, list)
         and value
@@ -363,9 +375,9 @@ def _slash_keyed_rows(value):
     ):
         return value
 
-    # Field-list group: single dict of slash keys, no repeat index in the payload.
-    # Wrap as a one-row list so the same flatten loop handles both shapes.
-    # Requiring "/" on every key excludes system dicts (_validation_status, etc.).
+    # A lone group dict has no repeat index, so wrap it as one row and let the
+    # same flatten loop handle it. Requiring "/" on every key excludes system
+    # dicts such as _validation_status.
     if (
         isinstance(value, dict)
         and value
@@ -373,7 +385,6 @@ def _slash_keyed_rows(value):
     ):
         return [value]
 
-    # Scalars, empty containers, geolocation, attachments, and anything else.
     return None
 
 
@@ -396,7 +407,7 @@ def flatten_kobotoolbox_submission(submission):
     """
     flat = {}
     for key, value in submission.items():
-        rows = _slash_keyed_rows(value)
+        rows = _get_flattenable_kobo_rows(value)
         if rows is None:
             flat[key] = value
             continue

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -342,15 +342,14 @@ def download_form_responses_and_attachments(
     return form_submissions, form_name, form_languages
 
 
-# TODO -YAGNI: Extract to f/common_logic/submission_flatten.py if/when ODK repeat/matrix
+# TODO - YAGNI: Extract to f/common_logic/submission_flatten.py if/when ODK repeat/matrix
 # flattening lands; not worth a common module until then.
 def _slash_keyed_rows(value):
     """Return the repeat/field-list rows to flatten, or ``None`` to keep as-is.
 
     Kobo emits repeat groups and matrices as a ``list[dict]`` (each row carrying
     at least one slash-separated key) and field-list groups as a lone ``dict``
-    whose keys are all slash-separated. Scalars, ``_geolocation``,
-    ``_attachments`` and empty containers return ``None`` and pass through.
+    whose keys are all slash-separated.
     """
     # Repeat group / matrix: list of row dicts, e.g.
     #   household_members: [{ "household_members/member/name": "Ada", ... }, ...]

--- a/f/connectors/kobotoolbox/tests/assets/server_responses.py
+++ b/f/connectors/kobotoolbox/tests/assets/server_responses.py
@@ -368,6 +368,38 @@ def _get_nested_submissions(uri, form_id):
             "_validation_status": {},
             "_submitted_by": "fixture_user",
         },
+        {
+            "_id": 900003,
+            "formhub/uuid": "cccccccccccccccccccccccccccccccc",
+            "village_name": "Village Gamma",
+            "interviewer_name": "Interviewer C",
+            # Repeat group nested inside another repeat group.
+            "first_group": [
+                {
+                    "first_group/second_group": [
+                        {
+                            "first_group/second_group/group_er3uf83_row/group_er3uf83_row_column": "John",
+                            "first_group/second_group/group_er3uf83_row/group_er3uf83_row_second_column": "Doe",
+                        },
+                        {
+                            "first_group/second_group/group_er3uf83_row/group_er3uf83_row_column": "Jane",
+                            "first_group/second_group/group_er3uf83_row/group_er3uf83_row_second_column": "Doe",
+                        },
+                    ]
+                },
+            ],
+            "__version__": "fixtureVersion01",
+            "meta/instanceID": "uuid:33333333-3333-3333-3333-333333333333",
+            "_xform_id_string": form_id,
+            "_uuid": "33333333-3333-3333-3333-333333333333",
+            "_attachments": [],
+            "_status": "submitted_via_web",
+            "_submission_time": "2026-01-15T12:00:00",
+            "_tags": [],
+            "_notes": [],
+            "_validation_status": {},
+            "_submitted_by": "fixture_user",
+        },
     ]
 
 

--- a/f/connectors/kobotoolbox/tests/assets/server_responses.py
+++ b/f/connectors/kobotoolbox/tests/assets/server_responses.py
@@ -1,6 +1,8 @@
 import posixpath
 from urllib.parse import urlencode
 
+nested_form_id = "fixture_nested_household"
+
 
 def kobo_form(uri, form_id, form_name):
     return {
@@ -97,165 +99,311 @@ def kobo_form(uri, form_id, form_name):
 def _get_all_submissions(uri, form_id):
     """Return all submission records for testing."""
     return [
-            {
-                "_id": 124961136,
-                "formhub/uuid": "f7bef041e8624f09946bff05ee5cbd4b",
-                "start": "2021-11-16T15:44:56.464-08:00",
-                "end": "2021-11-16T15:46:17.524-08:00",
-                "today": "2021-11-16",
-                "username": "cmi_admin_kobo_test",
-                "deviceid": "collect:pEo4VhQlQDnvDCNj",
-                "Record_your_current_location": "36.97012 -122.0109429 -14.432169171089349 4.969",
-                "Estimate_height_of_your_tree_in_meters": "18",
-                "I_like_this_tree_because": "shade food wildlife_habitat beauty",
-                "Take_a_photo_of_this_tree": "1637106370994.jpg",
-                "__version__": "vLnrnT6Pvzgeh4DVfj6eDz",
-                "meta/instanceID": "uuid:e58da38d-3eee-4bd7-8512-4a97ea8fbb01",
-                "_xform_id_string": form_id,
-                "_uuid": "e58da38d-3eee-4bd7-8512-4a97ea8fbb01",
-                "_attachments": [
-                    {
-                        "download_url": f"{uri}/api/v2/assets/{form_id}/data/124961136/attachments/46493730/",
-                        "download_large_url": f"{uri}/api/v2/assets/{form_id}/data/124961136/attachments/46493730/",
-                        "download_medium_url": f"{uri}/api/v2/assets/{form_id}/data/124961136/attachments/46493730/",
-                        "download_small_url": f"{uri}/api/v2/assets/{form_id}/data/124961136/attachments/46493730/",
-                        "mimetype": "image/jpeg",
-                        "filename": "cmi_admin_kobo_test/attachments/f7bef041e8624f09946bff05ee5cbd4b/e58da38d-3eee-4bd7-8512-4a97ea8fbb01/1637106370994.jpg",
-                        "instance": 124961136,
-                        "xform": 815328,
-                        "id": 46493730,
-                    }
-                ],
-                "_status": "submitted_via_web",
-                "_geolocation": [36.97012, -122.0109429],
-                "_submission_time": "2021-11-16T23:46:27",
-                "_tags": [],
-                "_notes": [],
-                "_validation_status": {},
-                "_submitted_by": "cmi_admin_kobo_test",
-            },
-            {
-                "_id": 125283733,
-                "formhub/uuid": "f7bef041e8624f09946bff05ee5cbd4b",
-                "start": "2021-11-18T07:13:40.976-06:00",
-                "end": "2021-11-18T07:14:16.131-06:00",
-                "today": "2021-11-18",
-                "username": "iamjeffg",
-                "deviceid": "collect:LNnwswilWRvq6o6r",
-                "Record_your_current_location": "44.92933032 -93.22059967 230.54217529296875 5.36",
-                "Estimate_height_of_your_tree_in_meters": "4",
-                "I_like_this_tree_because": "beauty wildlife_habitat",
-                "Take_a_photo_of_this_tree": "1637241249813.jpg",
-                "__version__": "vLnrnT6Pvzgeh4DVfj6eDz",
-                "meta/instanceID": "uuid:5c408d9d-6a76-4fbb-bf4e-9ed8f8e3e382",
-                "_xform_id_string": form_id,
-                "_uuid": "5c408d9d-6a76-4fbb-bf4e-9ed8f8e3e382",
-                "_attachments": [
-                    {
-                        "download_url": f"{uri}/api/v2/assets/{form_id}/data/125283733/attachments/46632148/",
-                        "download_large_url": f"{uri}/api/v2/assets/{form_id}/data/125283733/attachments/46632148/",
-                        "download_medium_url": f"{uri}/api/v2/assets/{form_id}/data/125283733/attachments/46632148/",
-                        "download_small_url": f"{uri}/api/v2/assets/{form_id}/data/125283733/attachments/46632148/",
-                        "mimetype": "image/jpeg",
-                        "filename": "cmi_admin_kobo_test/attachments/f7bef041e8624f09946bff05ee5cbd4b/5c408d9d-6a76-4fbb-bf4e-9ed8f8e3e382/1637241249813.jpg",
-                        "instance": 125283733,
-                        "xform": 815328,
-                        "id": 46632148,
-                    }
-                ],
-                "_status": "submitted_via_web",
-                "_geolocation": [44.92933032, -93.22059967],
-                "_submission_time": "2021-11-18T13:14:26",
-                "_tags": [],
-                "_notes": [],
-                "_validation_status": {},
-                "_submitted_by": "iamjeffg",
-            },
-            {
-                "_id": 125340283,
-                "formhub/uuid": "f7bef041e8624f09946bff05ee5cbd4b",
-                "start": "2021-11-18T09:22:01.306-08:00",
-                "end": "2021-11-18T09:50:29.560-08:00",
-                "today": "2021-11-17",
-                "username": "afleishman",
-                "simserial": "simserial not found",
-                "deviceid": "ee.kobotoolbox.org:pSpP4Tnigrggt7BV",
-                "Record_your_current_location": "36.95751 -122.028192 17.47799301147461 10",
-                "Estimate_height_of_your_tree_in_meters": "24",
-                "I_like_this_tree_because": "shade wildlife_habitat beauty",
-                "Take_a_photo_of_this_tree": "74B37D46-A4D4-440B-8509-6817D83BAD64-9_23_38.jpeg",
-                "__version__": "vLnrnT6Pvzgeh4DVfj6eDz",
-                "meta/instanceID": "uuid:6a0e819b-9d89-4b59-bd1e-38355dd2e05f",
-                "meta/deprecatedID": "uuid:bf66ca42-160c-4207-8d01-af7df2852945",
-                "_xform_id_string": form_id,
-                "_uuid": "6a0e819b-9d89-4b59-bd1e-38355dd2e05f",
-                "_attachments": [
-                    {
-                        "download_url": f"{uri}/api/v2/assets/{form_id}/data/125340283/attachments/46653884/",
-                        "download_large_url": f"{uri}/api/v2/assets/{form_id}/data/125340283/attachments/46653884/",
-                        "download_medium_url": f"{uri}/api/v2/assets/{form_id}/data/125340283/attachments/46653884/",
-                        "download_small_url": f"{uri}/api/v2/assets/{form_id}/data/125340283/attachments/46653884/",
-                        "mimetype": "image/jpeg",
-                        "filename": "cmi_admin_kobo_test/attachments/f7bef041e8624f09946bff05ee5cbd4b/bf66ca42-160c-4207-8d01-af7df2852945/74B37D46-A4D4-440B-8509-6817D83BAD64-9_23_38.jpeg",
-                        "instance": 125340283,
-                        "xform": 815328,
-                        "id": 46653884,
-                    }
-                ],
-                "_status": "submitted_via_web",
-                "_geolocation": [36.95751, -122.028192],
-                "_submission_time": "2021-11-18T17:26:02",
-                "_tags": [],
-                "_notes": [],
-                "_validation_status": {},
-                "_submitted_by": "afleishman",
-            },
-        ]
+        {
+            "_id": 124961136,
+            "formhub/uuid": "f7bef041e8624f09946bff05ee5cbd4b",
+            "start": "2021-11-16T15:44:56.464-08:00",
+            "end": "2021-11-16T15:46:17.524-08:00",
+            "today": "2021-11-16",
+            "username": "cmi_admin_kobo_test",
+            "deviceid": "collect:pEo4VhQlQDnvDCNj",
+            "Record_your_current_location": "36.97012 -122.0109429 -14.432169171089349 4.969",
+            "Estimate_height_of_your_tree_in_meters": "18",
+            "I_like_this_tree_because": "shade food wildlife_habitat beauty",
+            "Take_a_photo_of_this_tree": "1637106370994.jpg",
+            "__version__": "vLnrnT6Pvzgeh4DVfj6eDz",
+            "meta/instanceID": "uuid:e58da38d-3eee-4bd7-8512-4a97ea8fbb01",
+            "_xform_id_string": form_id,
+            "_uuid": "e58da38d-3eee-4bd7-8512-4a97ea8fbb01",
+            "_attachments": [
+                {
+                    "download_url": f"{uri}/api/v2/assets/{form_id}/data/124961136/attachments/46493730/",
+                    "download_large_url": f"{uri}/api/v2/assets/{form_id}/data/124961136/attachments/46493730/",
+                    "download_medium_url": f"{uri}/api/v2/assets/{form_id}/data/124961136/attachments/46493730/",
+                    "download_small_url": f"{uri}/api/v2/assets/{form_id}/data/124961136/attachments/46493730/",
+                    "mimetype": "image/jpeg",
+                    "filename": "cmi_admin_kobo_test/attachments/f7bef041e8624f09946bff05ee5cbd4b/e58da38d-3eee-4bd7-8512-4a97ea8fbb01/1637106370994.jpg",
+                    "instance": 124961136,
+                    "xform": 815328,
+                    "id": 46493730,
+                }
+            ],
+            "_status": "submitted_via_web",
+            "_geolocation": [36.97012, -122.0109429],
+            "_submission_time": "2021-11-16T23:46:27",
+            "_tags": [],
+            "_notes": [],
+            "_validation_status": {},
+            "_submitted_by": "cmi_admin_kobo_test",
+        },
+        {
+            "_id": 125283733,
+            "formhub/uuid": "f7bef041e8624f09946bff05ee5cbd4b",
+            "start": "2021-11-18T07:13:40.976-06:00",
+            "end": "2021-11-18T07:14:16.131-06:00",
+            "today": "2021-11-18",
+            "username": "iamjeffg",
+            "deviceid": "collect:LNnwswilWRvq6o6r",
+            "Record_your_current_location": "44.92933032 -93.22059967 230.54217529296875 5.36",
+            "Estimate_height_of_your_tree_in_meters": "4",
+            "I_like_this_tree_because": "beauty wildlife_habitat",
+            "Take_a_photo_of_this_tree": "1637241249813.jpg",
+            "__version__": "vLnrnT6Pvzgeh4DVfj6eDz",
+            "meta/instanceID": "uuid:5c408d9d-6a76-4fbb-bf4e-9ed8f8e3e382",
+            "_xform_id_string": form_id,
+            "_uuid": "5c408d9d-6a76-4fbb-bf4e-9ed8f8e3e382",
+            "_attachments": [
+                {
+                    "download_url": f"{uri}/api/v2/assets/{form_id}/data/125283733/attachments/46632148/",
+                    "download_large_url": f"{uri}/api/v2/assets/{form_id}/data/125283733/attachments/46632148/",
+                    "download_medium_url": f"{uri}/api/v2/assets/{form_id}/data/125283733/attachments/46632148/",
+                    "download_small_url": f"{uri}/api/v2/assets/{form_id}/data/125283733/attachments/46632148/",
+                    "mimetype": "image/jpeg",
+                    "filename": "cmi_admin_kobo_test/attachments/f7bef041e8624f09946bff05ee5cbd4b/5c408d9d-6a76-4fbb-bf4e-9ed8f8e3e382/1637241249813.jpg",
+                    "instance": 125283733,
+                    "xform": 815328,
+                    "id": 46632148,
+                }
+            ],
+            "_status": "submitted_via_web",
+            "_geolocation": [44.92933032, -93.22059967],
+            "_submission_time": "2021-11-18T13:14:26",
+            "_tags": [],
+            "_notes": [],
+            "_validation_status": {},
+            "_submitted_by": "iamjeffg",
+        },
+        {
+            "_id": 125340283,
+            "formhub/uuid": "f7bef041e8624f09946bff05ee5cbd4b",
+            "start": "2021-11-18T09:22:01.306-08:00",
+            "end": "2021-11-18T09:50:29.560-08:00",
+            "today": "2021-11-17",
+            "username": "afleishman",
+            "simserial": "simserial not found",
+            "deviceid": "ee.kobotoolbox.org:pSpP4Tnigrggt7BV",
+            "Record_your_current_location": "36.95751 -122.028192 17.47799301147461 10",
+            "Estimate_height_of_your_tree_in_meters": "24",
+            "I_like_this_tree_because": "shade wildlife_habitat beauty",
+            "Take_a_photo_of_this_tree": "74B37D46-A4D4-440B-8509-6817D83BAD64-9_23_38.jpeg",
+            "__version__": "vLnrnT6Pvzgeh4DVfj6eDz",
+            "meta/instanceID": "uuid:6a0e819b-9d89-4b59-bd1e-38355dd2e05f",
+            "meta/deprecatedID": "uuid:bf66ca42-160c-4207-8d01-af7df2852945",
+            "_xform_id_string": form_id,
+            "_uuid": "6a0e819b-9d89-4b59-bd1e-38355dd2e05f",
+            "_attachments": [
+                {
+                    "download_url": f"{uri}/api/v2/assets/{form_id}/data/125340283/attachments/46653884/",
+                    "download_large_url": f"{uri}/api/v2/assets/{form_id}/data/125340283/attachments/46653884/",
+                    "download_medium_url": f"{uri}/api/v2/assets/{form_id}/data/125340283/attachments/46653884/",
+                    "download_small_url": f"{uri}/api/v2/assets/{form_id}/data/125340283/attachments/46653884/",
+                    "mimetype": "image/jpeg",
+                    "filename": "cmi_admin_kobo_test/attachments/f7bef041e8624f09946bff05ee5cbd4b/bf66ca42-160c-4207-8d01-af7df2852945/74B37D46-A4D4-440B-8509-6817D83BAD64-9_23_38.jpeg",
+                    "instance": 125340283,
+                    "xform": 815328,
+                    "id": 46653884,
+                }
+            ],
+            "_status": "submitted_via_web",
+            "_geolocation": [36.95751, -122.028192],
+            "_submission_time": "2021-11-18T17:26:02",
+            "_tags": [],
+            "_notes": [],
+            "_validation_status": {},
+            "_submitted_by": "afleishman",
+        },
+    ]
 
 
-def kobo_form_submissions(uri, form_id, limit=100, start=0):
-    """
-    Return paginated form submissions for testing.
-    
-    Parameters
-    ----------
-    uri : str
-        The base URI of the KoboToolbox server
-    form_id : str
-        The form ID
-    limit : int, optional
-        The maximum number of results to return per page (default: 100, matching API behavior as of January 2026)
-    start : int, optional
-        The starting index for pagination (default: 0)
-    
-    Returns
-    -------
-    dict
-        A paginated response with count, next, previous, and results
-    """
-    all_submissions = _get_all_submissions(uri, form_id)
+def kobo_form_nested(uri, form_id, form_name="Household Survey Fixture"):
+    """Form metadata with repeat groups and field-list groups for flattening tests."""
+    return {
+        "name": form_name,
+        "uid": form_id,
+        "owner__username": "fixture_user",
+        "data": posixpath.join(uri, "api/v2/assets", form_id, "data/"),
+        "content": {
+            "schema": "1",
+            "survey": [
+                {
+                    "name": "village_name",
+                    "type": "text",
+                    "label": ["Village name"],
+                    "$qpath": "village_name",
+                    "$xpath": "village_name",
+                    "$autoname": "village_name",
+                },
+                {
+                    "name": "interviewer_name",
+                    "type": "text",
+                    "label": ["Interviewer name"],
+                    "$qpath": "interviewer_name",
+                    "$xpath": "interviewer_name",
+                    "$autoname": "interviewer_name",
+                },
+                {
+                    "name": "household_members",
+                    "type": "begin_repeat",
+                    "label": ["Household members"],
+                    "$qpath": "household_members",
+                    "$xpath": "household_members",
+                    "$autoname": "household_members",
+                },
+                {
+                    "name": "group_fixture_member_1",
+                    "type": "begin_group",
+                    "label": ["Member"],
+                    "$qpath": "household_members/group_fixture_member_1",
+                    "$xpath": "household_members/group_fixture_member_1",
+                    "$autoname": "group_fixture_member_1",
+                },
+                {
+                    "name": "group_fixture_member_1_name",
+                    "type": "text",
+                    "label": ["Member name"],
+                    "$qpath": "household_members/group_fixture_member_1/group_fixture_member_1_name",
+                    "$xpath": "household_members/group_fixture_member_1/group_fixture_member_1_name",
+                    "$autoname": "group_fixture_member_1_name",
+                },
+                {
+                    "name": "group_fixture_member_1_age",
+                    "type": "integer",
+                    "label": ["Member age"],
+                    "$qpath": "household_members/group_fixture_member_1/group_fixture_member_1_age",
+                    "$xpath": "household_members/group_fixture_member_1/group_fixture_member_1_age",
+                    "$autoname": "group_fixture_member_1_age",
+                },
+                {"type": "end_group"},
+                {"type": "end_repeat"},
+                {
+                    "name": "dwelling_counts",
+                    "type": "begin_group",
+                    "label": ["Dwelling counts"],
+                    "$qpath": "dwelling_counts",
+                    "$xpath": "dwelling_counts",
+                    "$autoname": "dwelling_counts",
+                },
+                {
+                    "name": "group_fixture_house_adults",
+                    "type": "integer",
+                    "label": ["Adults"],
+                    "$qpath": "dwelling_counts/group_fixture_house/group_fixture_house_adults",
+                    "$xpath": "dwelling_counts/group_fixture_house/group_fixture_house_adults",
+                    "$autoname": "group_fixture_house_adults",
+                },
+                {
+                    "name": "group_fixture_house_children",
+                    "type": "integer",
+                    "label": ["Children"],
+                    "$qpath": "dwelling_counts/group_fixture_house/group_fixture_house_children",
+                    "$xpath": "dwelling_counts/group_fixture_house/group_fixture_house_children",
+                    "$autoname": "group_fixture_house_children",
+                },
+                {"type": "end_group"},
+            ],
+            "choices": [],
+            "settings": {"version": "1", "default_language": "English (en)"},
+            "translated": ["label"],
+            "translations": [None],
+        },
+    }
+
+
+def _get_nested_submissions(uri, form_id):
+    """Return synthetic submissions with repeat groups and field-list dicts."""
+    return [
+        {
+            "_id": 900001,
+            "formhub/uuid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "village_name": "Village Alpha",
+            "interviewer_name": "Interviewer A",
+            "household_members": [
+                {
+                    "household_members/group_fixture_member_1/group_fixture_member_1_name": "Person One",
+                    "household_members/group_fixture_member_1/group_fixture_member_1_age": "25",
+                },
+                {
+                    "household_members/group_fixture_member_1/group_fixture_member_1_name": "Person Two",
+                    "household_members/group_fixture_member_1/group_fixture_member_1_age": "30",
+                },
+            ],
+            "summary_counts/adults": "2",
+            "__version__": "fixtureVersion01",
+            "meta/instanceID": "uuid:11111111-1111-1111-1111-111111111111",
+            "_xform_id_string": form_id,
+            "_uuid": "11111111-1111-1111-1111-111111111111",
+            "_attachments": [],
+            "_status": "submitted_via_web",
+            "_geolocation": [10.0, 20.0],
+            "_submission_time": "2026-01-15T10:00:00",
+            "_tags": [],
+            "_notes": [],
+            "_validation_status": {},
+            "_submitted_by": "fixture_user",
+        },
+        {
+            "_id": 900002,
+            "formhub/uuid": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "village_name": "Village Beta",
+            "interviewer_name": "Interviewer B",
+            "household_members": [
+                {
+                    "household_members/group_fixture_member_1/group_fixture_member_1_name": "Person Three",
+                    "household_members/group_fixture_member_1/group_fixture_member_1_age": "40",
+                },
+            ],
+            "dwelling_counts": {
+                "dwelling_counts/group_fixture_house/group_fixture_house_adults": "2",
+                "dwelling_counts/group_fixture_house/group_fixture_house_children": "1",
+            },
+            "__version__": "fixtureVersion01",
+            "meta/instanceID": "uuid:22222222-2222-2222-2222-222222222222",
+            "_xform_id_string": form_id,
+            "_uuid": "22222222-2222-2222-2222-222222222222",
+            "_attachments": [],
+            "_status": "submitted_via_web",
+            "_submission_time": "2026-01-15T11:00:00",
+            "_tags": [],
+            "_notes": [],
+            "_validation_status": {},
+            "_submitted_by": "fixture_user",
+        },
+    ]
+
+
+def _paginate_submissions(uri, form_id, all_submissions, limit=100, start=0):
     total_count = len(all_submissions)
-    
-    # Paginate results
     end = start + limit
     results = all_submissions[start:end]
-    
-    # Build next URL if there are more results
+
     next_url = None
     if end < total_count:
         next_params = {"limit": limit, "start": end}
         next_url = f"{uri}/api/v2/assets/{form_id}/data/?{urlencode(next_params)}"
-    
-    # Build previous URL if we're not on the first page
+
     previous_url = None
     if start > 0:
         prev_start = max(0, start - limit)
         prev_params = {"limit": limit, "start": prev_start}
         previous_url = f"{uri}/api/v2/assets/{form_id}/data/?{urlencode(prev_params)}"
-    
+
     return {
         "count": total_count,
         "next": next_url,
         "previous": previous_url,
         "results": results,
     }
+
+
+def kobo_form_submissions(uri, form_id, limit=100, start=0):
+    """Return paginated form submissions for testing"""
+    return _paginate_submissions(
+        uri, form_id, _get_all_submissions(uri, form_id), limit, start
+    )
+
+
+def kobo_nested_form_submissions(uri, form_id, limit=100, start=0):
+    """Return paginated nested-form submissions for flattening tests."""
+    return _paginate_submissions(
+        uri, form_id, _get_nested_submissions(uri, form_id), limit, start
+    )

--- a/f/connectors/kobotoolbox/tests/conftest.py
+++ b/f/connectors/kobotoolbox/tests/conftest.py
@@ -22,19 +22,35 @@ def mocked_responses():
 def _paginated_data_callback(request):
     """Callback to handle paginated data requests with query parameters."""
     import urllib.parse
-    
+
     # Parse query parameters from the request
     parsed_url = urllib.parse.urlparse(request.url)
     query_params = urllib.parse.parse_qs(parsed_url.query)
-    
+
     # Default to 100 if limit not specified, matching API behavior as of January 2026
     limit = int(query_params.get("limit", [100])[0])
     start = int(query_params.get("start", [0])[0])
-    
+
     response_data = server_responses.kobo_form_submissions(
         server_url, form_id, limit=limit, start=start
     )
-    
+
+    return (200, {}, json.dumps(response_data))
+
+
+def _paginated_nested_data_callback(request):
+    """Paginated data callback for the nested repeat-group fixture form."""
+    import urllib.parse
+
+    parsed_url = urllib.parse.urlparse(request.url)
+    query_params = urllib.parse.parse_qs(parsed_url.query)
+    limit = int(query_params.get("limit", [100])[0])
+    start = int(query_params.get("start", [0])[0])
+
+    response_data = server_responses.kobo_nested_form_submissions(
+        server_url, server_responses.nested_form_id, limit=limit, start=start
+    )
+
     return (200, {}, json.dumps(response_data))
 
 
@@ -90,10 +106,39 @@ def koboserver_no_translations(mocked_responses):
 def koboserver_with_pagination(mocked_responses):
     """Fixture with many submissions to test pagination (3 pages with limit=1)."""
     metadata = server_responses.kobo_form(server_url, form_id, form_name)
-    
+
     _register_common_mocks(mocked_responses, form_id, metadata)
-    
+
     return _build_koboserver_fixture(metadata)
+
+
+@pytest.fixture
+def koboserver_nested(mocked_responses):
+    """Fixture with repeat groups and field-list dict payloads for flattening tests."""
+    nested_id = server_responses.nested_form_id
+    metadata = server_responses.kobo_form_nested(server_url, nested_id)
+
+    mocked_responses.get(
+        f"{server_url}/api/v2/assets/{nested_id}/",
+        json=metadata,
+        status=200,
+    )
+    mocked_responses.add_callback(
+        responses.GET,
+        re.compile(rf"{server_url}/api/v2/assets/{nested_id}/data/"),
+        callback=_paginated_nested_data_callback,
+        content_type="application/json",
+    )
+
+    @dataclass
+    class KoboServer:
+        account: dict
+        form_id: str
+
+    return KoboServer(
+        dict(server_url=server_url, api_key="Callooh!Callay!"),
+        nested_id,
+    )
 
 
 @pytest.fixture

--- a/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
+++ b/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
@@ -268,6 +268,53 @@ def test_flatten_kobotoolbox_submission__preserves_system_fields():
     assert result["household_members"] == []
 
 
+def test_flatten_kobotoolbox_submission__deeply_nested_repeat():
+    """A repeat group nested inside another repeat group must flatten all the way down.
+
+    Kobo emits the inner repeat as a slash-keyed ``list[dict]`` under each outer
+    row, so the flattener has to recurse instead of leaving the inner list as a
+    JSON blob under ``first_group/{i}/second_group``.
+    """
+    submission = {
+        "first_group": [
+            {
+                "first_group/second_group": [
+                    {
+                        "first_group/second_group/group_er3uf83_row/group_er3uf83_row_column": "John",
+                        "first_group/second_group/group_er3uf83_row/group_er3uf83_row_second_column": "Doe",
+                    },
+                    {
+                        "first_group/second_group/group_er3uf83_row/group_er3uf83_row_column": "Jane",
+                        "first_group/second_group/group_er3uf83_row/group_er3uf83_row_second_column": "Doe",
+                    },
+                ]
+            },
+            {
+                "first_group/second_group": [
+                    {
+                        "first_group/second_group/group_er3uf83_row/group_er3uf83_row_column": "Foo",
+                        "first_group/second_group/group_er3uf83_row/group_er3uf83_row_second_column": "Bar",
+                    },
+                ]
+            },
+        ],
+    }
+    result = flatten_kobotoolbox_submission(submission)
+
+    assert "first_group" not in result
+    # Nothing should remain as a nested container once fully flattened.
+    assert not any(isinstance(v, (list, dict)) for v in result.values())
+    assert result["first_group/1/second_group/1/group_er3uf83_row_column"] == "John"
+    assert result["first_group/1/second_group/2/group_er3uf83_row_column"] == "Jane"
+    assert (
+        result["first_group/1/second_group/2/group_er3uf83_row_second_column"] == "Doe"
+    )
+    assert result["first_group/2/second_group/1/group_er3uf83_row_column"] == "Foo"
+    assert (
+        result["first_group/2/second_group/1/group_er3uf83_row_second_column"] == "Bar"
+    )
+
+
 def test_script_e2e__nested_repeats(koboserver_nested, pg_database, tmp_path):
     asset_storage = tmp_path / "datalake"
     table_name = "kobo_nested_repeats"
@@ -283,7 +330,7 @@ def test_script_e2e__nested_repeats(koboserver_nested, pg_database, tmp_path):
     with psycopg.connect(autocommit=True, **pg_database) as conn:
         with conn.cursor() as cursor:
             cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
-            assert cursor.fetchone()[0] == 2
+            assert cursor.fetchone()[0] == 3
 
             cursor.execute(
                 f'SELECT "group_fixture_member_1_name__1__household_members" '
@@ -296,3 +343,11 @@ def test_script_e2e__nested_repeats(koboserver_nested, pg_database, tmp_path):
                 f"FROM {table_name} WHERE _id = '900002'"
             )
             assert cursor.fetchone()[0] == "2"
+
+            # A repeat nested inside a repeat is flattened all the way down, so
+            # even the innermost leaf lands in its own reversed/underscored column.
+            cursor.execute(
+                f'SELECT "group_er3uf83_row_column__2__second_group__1__first_group" '
+                f"FROM {table_name} WHERE _id = '900003'"
+            )
+            assert cursor.fetchone()[0] == "Jane"

--- a/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
+++ b/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import psycopg
 
 from f.connectors.kobotoolbox.kobotoolbox_responses import (
+    flatten_kobotoolbox_submission,
     main,
     transform_kobotoolbox_form_data,
 )
@@ -206,3 +207,92 @@ def test_pagination(koboserver_with_pagination, pg_database, tmp_path):
             assert "124961136" in ids
             assert "125283733" in ids
             assert "125340283" in ids
+
+
+def test_flatten_kobotoolbox_submission__repeat_group():
+    submission = {
+        "household_members": [
+            {
+                "household_members/group_fixture_member_1/group_fixture_member_1_name": "Person One",
+                "household_members/group_fixture_member_1/group_fixture_member_1_age": "25",
+            },
+            {
+                "household_members/group_fixture_member_1/group_fixture_member_1_name": "Person Two",
+                "household_members/group_fixture_member_1/group_fixture_member_1_age": "30",
+            },
+        ],
+    }
+    result = flatten_kobotoolbox_submission(submission)
+
+    assert "household_members" not in result
+    assert result["household_members/1/group_fixture_member_1_name"] == "Person One"
+    assert result["household_members/1/group_fixture_member_1_age"] == "25"
+    assert result["household_members/2/group_fixture_member_1_name"] == "Person Two"
+    assert result["household_members/2/group_fixture_member_1_age"] == "30"
+
+
+def test_flatten_kobotoolbox_submission__field_list_dict():
+    submission = {
+        "dwelling_counts": {
+            "dwelling_counts/group_fixture_house/group_fixture_house_adults": "2",
+            "dwelling_counts/group_fixture_house/group_fixture_house_children": "1",
+        },
+    }
+    result = flatten_kobotoolbox_submission(submission)
+
+    assert "dwelling_counts" not in result
+    assert result["dwelling_counts/1/group_fixture_house_adults"] == "2"
+    assert result["dwelling_counts/1/group_fixture_house_children"] == "1"
+
+
+def test_flatten_kobotoolbox_submission__preserves_system_fields():
+    submission = {
+        "_id": 1,
+        "_geolocation": [10.0, 20.0],
+        "_attachments": [
+            {"download_url": "http://example.org/file.jpg", "filename": "file.jpg"}
+        ],
+        "_validation_status": {},
+        "_tags": [],
+        "summary_counts/adults": "2",
+        "household_members": [],
+    }
+    result = flatten_kobotoolbox_submission(submission)
+
+    assert result["_id"] == 1
+    assert result["_geolocation"] == [10.0, 20.0]
+    assert result["_attachments"] == submission["_attachments"]
+    assert result["_validation_status"] == {}
+    assert result["_tags"] == []
+    assert result["summary_counts/adults"] == "2"
+    assert result["household_members"] == []
+
+
+def test_script_e2e__nested_repeats(koboserver_nested, pg_database, tmp_path):
+    asset_storage = tmp_path / "datalake"
+    table_name = "kobo_nested_repeats"
+
+    main(
+        koboserver_nested.account,
+        koboserver_nested.form_id,
+        pg_database,
+        table_name,
+        asset_storage,
+    )
+
+    with psycopg.connect(autocommit=True, **pg_database) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+            assert cursor.fetchone()[0] == 2
+
+            cursor.execute(
+                f'SELECT "group_fixture_member_1_name__1__household_members" '
+                f"FROM {table_name} WHERE _id = '900001'"
+            )
+            assert cursor.fetchone()[0] == "Person One"
+
+            cursor.execute(
+                f'SELECT "group_fixture_house_adults__1__dwelling_counts" '
+                f"FROM {table_name} WHERE _id = '900002'"
+            )
+            assert cursor.fetchone()[0] == "2"

--- a/f/connectors/odk/odk_responses.py
+++ b/f/connectors/odk/odk_responses.py
@@ -269,9 +269,8 @@ def transform_odk_form_data(form_data, form_name=None):
     list
         A list of transformed form submissions with added metadata fields and formatted geometry.
     """
-    # TODO: ODK repeat groups / matrix payloads are not flattened yet (see Kobo
-    # flatten_kobotoolbox_submission). Extract to f/common_logic/submission_flatten.py
-    # when implementing — YAGNI until then.
+    # TODO: ODK repeat groups / matrix payloads are not flattened yet. See the
+    # KoboToolbox connector and README.md for details on how it is handled there.
     for submission in form_data:
         # Add metadata fields
         # Handle both API format (__id) and CSV format (KEY)

--- a/f/connectors/odk/odk_responses.py
+++ b/f/connectors/odk/odk_responses.py
@@ -269,6 +269,9 @@ def transform_odk_form_data(form_data, form_name=None):
     list
         A list of transformed form submissions with added metadata fields and formatted geometry.
     """
+    # TODO: ODK repeat groups / matrix payloads are not flattened yet (see Kobo
+    # flatten_kobotoolbox_submission). Extract to f/common_logic/submission_flatten.py
+    # when implementing — YAGNI until then.
     for submission in form_data:
         # Add metadata fields
         # Handle both API format (__id) and CSV format (KEY)


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-scripts-hub/issues/248

**Note to the reviewer:** +340 of the line difference is just fixtures and `conftest` stuff. The actual code changes are +67 lines, and +90 are tests.

## What I changed and why

- Added `flatten_kobotoolbox_submission()` in the Kobo connector script and call it from `transform_kobotoolbox_form_data()` so repeat groups and matrix questions become wide `{group}/{index}/{leaf}` keys instead of one JSON cell. Existing `reverse_properties_separated_by="/"` then maps those to flat SQL columns. See README and docstrings for more info.

## How I convinced myself this is right

- In terms of the "why do this", by working with one of our highest tier partners who wanted to analyze matrix results and was not able to work with a JSON blob dumped in one cell. We had never encountered matrix questions in a Kobo questionnaire before this.
- In terms of "how I know this works", besides tests, I tried it in production with real data. The result is as described in the README. 

## What I'm not doing here

- Apply this to ODK (also uses XLSForm), but I did leave clear TODOs to track that future need if it arises.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

As I was working with a partner in country and didn't have a lot of time, I used Claude Opus 4.7 in planning mode to scheme this work out, and had it implement it too. Then I made various edits to ensure the code and its documentation is legible to me. I screened the code carefully to make sure it is valid and maintainable, making a few improvements here and there.