### PR TITLE
Revise contributing for large PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,11 @@ As code author:
 - When you anticipate a PR will necessarily be large, loop in your reviewer early: they may have ideas that reduce scope, or they may want to agree in advance on a review approach.
 - The first reviewer of the code or documentation that you submit should be YOU!  (More at https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/)
 - Ultimately the responsibility for bug-free code is on the code author, not the reviewer.
+- Orient your reviewer. Use direct outreach or the PR description to convey scope, flag what's
+  boilerplate or auto-generated, and highlight where you want focused attention.
 - Code review is not limited to approval/rejection of PRs. Consider involving a collaborator
-earlier in the process, before the code is finished. Ask them for a narrower review—e.g., a
-design review or to focus on a specific part of the code change.  Use Draft PRs, or prose documents outside of Github.
+  earlier in the process, before the code is finished. Ask them to review your design or
+  implementation plan before coding. Use Draft PRs or circulate a prose document outside of Github.
 
 As a reviewer:
 - [This Code Review Checklist](http://web.archive.org/web/20180219163514/https://blog.fogcreek.com/increase-defect-detection-with-our-code-review-checklist-example/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Create new Github Issues using the templates wherever possible.
 
 **We release from the `main` branch, so code merged here should always be stable.**
 
-Prefer short lived features branches.
+Prefer short-lived feature branches.
 - Piecemeal progress towards broad code changes should merge to long-running branches until
   everything there is stable and deployable, at which point the long-running branch gets merged
   to `main`.
@@ -37,7 +37,7 @@ Prefer short lived features branches.
 ## PR Review & Committing code
 
 Code review is encouraged as a powerful tool for learning.  Benefits include
-- Spread knowledge of the code base throughout the team: reviewing code is a remarkably effective way to learn the codebase.
+- Spread knowledge of the code base throughout the team: reviewing code is a remarkably effective way to learn the codebase, and ensures at least one other person besides the author can maintain it.
 - Expose everyone to different approaches.
 - Ensure code is readable (and therefore maintainable).
 - Yield better software.
@@ -58,10 +58,8 @@ As code author:
   implementation plan before coding. Use Draft PRs or circulate a prose document outside of Github.
 
 As a reviewer:
-- [This Code Review Checklist](http://web.archive.org/web/20180219163514/https://blog.fogcreek.com/increase-defect-detection-with-our-code-review-checklist-example/)
-  gives concrete examples of what reviewers should look for.
+- The reviewer's core job is to understand what the code does and how. If they can't, the code will be hard to maintain; that should be fixed now, while the author still remembers why they wrote it this way. "I find this very hard to follow" is important feedback, even if the code's behavior is technically correct.
 - Be kind & helpful, but do not ignore problems for the sake of avoiding conflict.
-- "I find this very hard to follow" is valid feedback, even if the code's behavior is technically correct.
 - Ability for code review to find defects diminishes with longer PRs: Feel free to reject any
   review that adds more than 400 lines of new code
   unless you believe it's as cohesive as it can be. (no upper limit on deletions!)
@@ -69,6 +67,8 @@ As a reviewer:
   clearer ways of solving the problem at hand), but do not comment only because
   the author did something differently than you would have. Use "FYI" in your
   comment to distinguish comments that do not require action by the author.
+- [This Code Review Checklist](http://web.archive.org/web/20180219163514/https://blog.fogcreek.com/increase-defect-detection-with-our-code-review-checklist-example/)
+  gives concrete examples of what reviewers should look for.
 
 > [!TIP]
 > If you're unsure how to break up a large PR, see [CONTRIBUTING_EXAMPLES.md](./CONTRIBUTING_EXAMPLES.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Code review is encouraged as a powerful tool for learning.  Benefits include
 
 The ideal PR is **cohesive**, and most cohesive PRs are quite small (< 200 new lines).
 * Prefer eliminating scope over splitting a cohesive changeset arbitrarily. Extraneous or unrelated changes may be moved to their own (also small) PR.
-* Sometimes a large refactor is best reviewed as one cohesive PR (i.e. where all changes depend on each other, or there is no incremental value of a partial deploy). In this case, a commit-by-commit review pattern can help: see [CONTRIBUTING_EXAMPLES.md](./CONTRIBUTING_EXAMPLES.md).
+* Sometimes a large refactor is best reviewed as one cohesive PR (i.e. where all changes depend on each other, or there is no incremental value of a partial deploy). In this case, a commit-by-commit review pattern can help: see [CONTRIBUTING_EXAMPLES.md](./CONTRIBUTING_EXAMPLES.md#example-commit-by-commit-review-for-large-cohesive-prs).
 
 As code author:
 - Keep scope in-check. Limit PRs to the goal at hand: no extra code beyond what is absolutely necessary to solve the problem.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,30 +36,33 @@ Prefer short lived features branches.
 
 ## PR Review & Committing code
 
-Keep scope in-check: limit PRs to the goal at hand.  No extra code beyond what is absolutely
-necessary to solve the problem the user provides.  We encourage multiple commits or PRs for an
-Issue. e.g. each implementation step might get its own PR.
-
 Code review is encouraged as a powerful tool for learning.  Benefits include
 - Spread knowledge of the code base throughout the team: reviewing code is a remarkably effective way to learn the codebase.
 - Expose everyone to different approaches.
 - Ensure code is readable (and therefore maintainable).
 - Yield better software.
 
+The ideal PR is **cohesive**, and most cohesive PRs are quite small (< 200 new lines).
+* Prefer eliminating scope over splitting a cohesive changeset arbitrarily. Extraneous or unrelated changes may be moved to their own (also small) PR.
+* Sometimes a large refactor is best reviewed as one cohesive PR (i.e. where all changes depend on each other, or there is no incremental value of a partial deploy). In this case, a commit-by-commit review pattern can help: see [CONTRIBUTING_EXAMPLES.md](./CONTRIBUTING_EXAMPLES.md).
+
 As code author:
+- Keep scope in-check. Limit PRs to the goal at hand: no extra code beyond what is absolutely necessary to solve the problem.
+- When you anticipate a PR will necessarily be large, loop in your reviewer early: they may have ideas that reduce scope, or they may want to agree in advance on a review approach.
 - The first reviewer of the code or documentation that you submit should be YOU!  (More at https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/)
 - Ultimately the responsibility for bug-free code is on the code author, not the reviewer.
 - Code review is not limited to approval/rejection of PRs. Consider involving a collaborator
 earlier in the process, before the code is finished. Ask them for a narrower review—e.g., a
-design review or to focus on a specific part of the code change.
+design review or to focus on a specific part of the code change.  Use Draft PRs, or prose documents outside of Github.
 
 As a reviewer:
 - [This Code Review Checklist](http://web.archive.org/web/20180219163514/https://blog.fogcreek.com/increase-defect-detection-with-our-code-review-checklist-example/)
   gives concrete examples of what reviewers should look for.
-- Be kind & helpful, but do not be "nice" for the sake of avoiding conflict.
+- Be kind & helpful, but do not ignore problems for the sake of avoiding conflict.
 - "I find this very hard to follow" is valid feedback, even if the code's behavior is technically correct.
 - Ability for code review to find defects diminishes with longer PRs: Feel free to reject any
-  review that adds more than 400 lines of new code. (no upper limit on deletions!)
+  review that adds more than 400 lines of new code
+  unless you believe it's as cohesive as it can be. (no upper limit on deletions!)
 - Feel free to use code review as an instructional forum (for example suggesting
   clearer ways of solving the problem at hand), but do not comment only because
   the author did something differently than you would have. Use "FYI" in your

--- a/CONTRIBUTING_EXAMPLES.md
+++ b/CONTRIBUTING_EXAMPLES.md
@@ -2,10 +2,32 @@ These examples illustrate practical workflows that support [our contributing gui
 
 They are not new rules, but you may find them helpful in staying consistent with the guidelines.
 
+## Example: Commit-by-Commit Review for Large Cohesive PRs
+
+Some changes are necessarily large, even when every change is in direct service of the goal at hand: maybe every line depends on every other line, or partial deployment would deliver no incremental value. Examples include adding the same feature to many scripts, changing an ORM, or restructuring a database migration strategy. Stacked PRs don't serve these well because the split the context a reviewer needs.
+
+For these, structure a single PR to guide the reviewer through it commit-by-commit:
+* Organize commits as a narrative. Each commit should represent one logical step in the refactor, in the order a reviewer should read them.
+* Write a commit index in the PR description. List each commit with a brief prose summary of what's happening and why. This is the reviewer's map. Example PR description structure:
+
+    This PR makes all ETL scripts idempotent.
+
+    | SHA     | Commit                             | Comment       |
+    |---------|------------------------------------|---------------|
+    | abc1234 | Extract shared helpers             | Centralizes upsert logic. No behavior change |
+    | def5678 | Make ingest_orders.py idempotent   | Adds unique constraint on (order_id, source) so duplicate runs produce no duplicate rows. |
+    | ghi9012 | Make ingest_products.py idempotent | Same pattern as orders. |
+    | jkl3456 | Drop cleanup from run_all.py       | Now redundant |
+
+As author: Keep each commit self-contained enough to narrate. It helps to draft the index first before changing code, and this is your implementation plan.
+
+As reviewer: review commit-by-commit using the index as your map, rather than the unified diff.
 
 ## Example: Stacked or Dependent PRs Workflow
 
-When multiple PRs build upon each other -- for example `main ← PR1 ← PR2 ← PR3`:
+When work can be broken into **independently deployable** and **independently reviewable** pieces, prefer multiple small PRs over one larger one. The smaller PRs get earlier review turnaround, and with and no single controversial change blocking delivery of everything else, smaller PRs merge faster and so value ships sooner.
+
+Ideally this can be done even without the different PRs depending on each other, i.e. all target `main`. However when multiple PRs must build upon each other -- for example `main ← PR1 ← PR2 ← PR3` -- the pattern is as follows:
 
 1. **Start a long-running branch other than `main`.** Many repos deploy straight from `main`, so this branch prevents features landing in `main` until they are complete.
     - Example: `git checkout -b 191 main` becomes the integration point for a feature family.
@@ -22,7 +44,7 @@ When multiple PRs build upon each other -- for example `main ← PR1 ← PR2 ←
         - PR2: "Author wants to merge _n_ commits into [**`191`**] from `191b-types`"
         - Actually I think Github sometimes does this for you.
     - From the reviewers point of view, the patchset between this PR and its target never changes (it's always the same diff to review), nor does the PR scope or description need to change.
-5. **Use merge commits.**  As code author, when merging a branch, choosing the "Merge Commit" method will simplify future meregs to of other branches.
+5. **Use merge commits.**  As code author, when merging a branch, choosing the "Merge Commit" method will simplify future merges to of other branches.
     - Bring other open PRs up-to-date by running, on their branches, `git merge 191`.
     - When doing a Dependent PR Workflow like this I almost never `git rebase` or `squash` commits that exist in a different branch. Those operations will just introduce conflicts that are tedious to clean up. `git merge` is the answer for both the upstream branch and the downstream branch.
 6. **Iterate and stabilize the long-running branch.** Keep merging small PRs until `191` is stable and deployable.


### PR DESCRIPTION
## Goal

Revise `CONTRIBUTING.md` guidelines to acknowledge necessarily large PRs. 

## What I changed and why

It acknowledges that certain refactors are legitimately large.
- The solution is the guidelines now focus as much on cohesion of PRs as size.
- It provides a pattern of using a single commit-indexed PR to handle that (in `CONTRIBUTING_EXAMPLES.md`).

It also ramps up nudging toward pre-review consultation and communication with your reviewer.

## How I convinced myself this is right

This guidance comes from a series of conversations within our team, when we were doing a number of large refactors.


