### PR TITLE
Use dynamic class to hide convert lat/lon to GeoJSON for non-CSV uploads

### DIFF
--- a/f/apps/gc_dataset_importer.app/app.yaml
+++ b/f/apps/gc_dataset_importer.app/app.yaml
@@ -30,6 +30,10 @@ value:
       container:
         class: ''
         style: ''
+    selectcomponent:
+      input:
+        class: ''
+        style: ''
     steppercomponent:
       container:
         class: ''
@@ -167,20 +171,22 @@ value:
               language: frontend
               path: f/apps/gc_dataset_importer/0_Form_stepper_validations
               suggestedRefreshOn:
-                - id: lonLatToggle
+                - id: state
+                  key: latitudeCol
+                - id: state
+                  key: longitudeCol
+                - id: selectExistingDataset
                   key: result
                 - id: longitudeCol
                   key: result
-                - id: state
-                  key: uploadSuccess
                 - id: latitudeCol
                   key: result
                 - id: state
-                  key: validSqlName
-                - id: selectExistingDataset
-                  key: result
+                  key: uploadSuccess
                 - id: enterNewDatasetName
                   key: values
+                - id: lonLatToggle
+                  key: result
         configuration: {}
         customCss:
           container:
@@ -1293,9 +1299,21 @@ value:
           customCss:
             container:
               class: ''
+              evalClass:
+                type: evalv2
+                connections:
+                  - id: outputFormat
+                    componentId: state
+                expr: 'state.outputFormat !== "csv" ? "hidden" : ""'
+                fieldType: text
               style: ''
             text:
-              class: font-bold
+              class: ''
+              evalClass:
+                type: evalv2
+                connections: []
+                expr: ''
+                fieldType: text
               style: ''
           horizontalAlignment: center
           recomputeIds: []
@@ -1348,6 +1366,13 @@ value:
               style: ''
             text:
               class: ''
+              evalClass:
+                type: evalv2
+                connections:
+                  - id: outputFormat
+                    componentId: state
+                expr: 'state.outputFormat !== "csv" ? "hidden" : ""'
+                fieldType: text
               style: 'font-weight: normal;'
           horizontalAlignment: center
           verticalAlignment: center
@@ -1393,6 +1418,13 @@ value:
               style: ''
             text:
               class: ''
+              evalClass:
+                type: evalv2
+                connections:
+                  - id: outputFormat
+                    componentId: state
+                expr: 'state.outputFormat !== "csv" ? "hidden" : ""'
+                fieldType: text
               style: ''
           horizontalAlignment: left
           verticalAlignment: top
@@ -1438,6 +1470,13 @@ value:
               style: ''
             text:
               class: ''
+              evalClass:
+                type: evalv2
+                connections:
+                  - id: outputFormat
+                    componentId: state
+                expr: 'state.outputFormat !== "csv" ? "hidden" : ""'
+                fieldType: text
               style: ''
           horizontalAlignment: left
           verticalAlignment: top
@@ -1505,6 +1544,13 @@ value:
           customCss:
             input:
               class: ''
+              evalClass:
+                type: evalv2
+                connections:
+                  - id: outputFormat
+                    componentId: state
+                expr: 'state.outputFormat !== "csv" ? "hidden" : ""'
+                fieldType: text
               style: ''
           onSelect:
             - bg_6
@@ -1574,6 +1620,13 @@ value:
           customCss:
             input:
               class: ''
+              evalClass:
+                type: evalv2
+                connections:
+                  - id: outputFormat
+                    componentId: state
+                expr: 'state.outputFormat !== "csv" ? "hidden" : ""'
+                fieldType: text
               style: ''
           onSelect:
             - bg_4


### PR DESCRIPTION
## Goal

I learned about [dynamic styling](https://www.windmill.dev/docs/apps/app_configuration_settings/app_styling#dynamic-styling) in Windmill apps recently and figured we could take advantage of this feature to selectively hide the "Convert lat/lon fields to GeoJSON?" components if it's not a CSV upload.

## Screenshots

If CSV:

<img width="900" height="751" alt="image" src="https://github.com/user-attachments/assets/53fa59df-f20b-4487-881a-78b60363c77f" />

If non-CSV:

<img width="900" height="751" alt="image" src="https://github.com/user-attachments/assets/33a04402-5bff-47ff-9f5d-667e59a446ce" />

## What I changed and why

- Add a dynamic styling expression `state.outputFormat !== "csv" ? "hidden" : ""`.
- The rest of the changes are just noise

## How I convinced myself this is right

Trying it in runtime (as per screenshots)

## What I'm not doing here

You might be wondering if we can vertically center the "Is this dataset from a known source or tool?" section, if the conversion stuff is hidden. I think that would be tricky, with responsive design considerations. I think the negative space is an acceptable tradeoff for lessened mental burden of not needing to think about this section if it's not relevant.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None