### PR TITLE
Remove "if file exists then don't download" check for ArcGIS anonymous download script

### DIFF
--- a/f/connectors/arcgis/arcgis_download_feature_layer_anonymously.py
+++ b/f/connectors/arcgis/arcgis_download_feature_layer_anonymously.py
@@ -392,10 +392,6 @@ def fetch_layer_data(
     filename = storage_path / f"{layer_name}.{output_format}"
     relative_output = Path(storage_path.name) / f"{layer_name}.{output_format}"
 
-    if filename.exists():
-        logger.info("File %s already exists. Skipping download.", filename)
-        return relative_output
-
     base_feature_url = f"https://{subdomain}.arcgis.com/{service_id}/arcgis/rest/services/{feature_id}/FeatureServer"
 
     records = fetch_features(session, base_feature_url, layer_index)

--- a/f/connectors/arcgis/tests/arcgis_download_feature_layer_anonymously_test.py
+++ b/f/connectors/arcgis/tests/arcgis_download_feature_layer_anonymously_test.py
@@ -273,3 +273,32 @@ def test_fetch_layer_data(arcgis_anonymous_server, tmp_path, mocked_responses):
             data = json.load(f)
         assert data["type"] == "FeatureCollection"
         assert len(data["features"]) >= 1
+
+
+def test_layer_overwrites_existing_file(arcgis_anonymous_server, tmp_path):
+    """Existing layer files are overwritten on re-fetch."""
+    asset_storage = tmp_path / "datalake"
+    folder_name = "arcgis_overwrite"
+    expected_file = asset_storage / folder_name / "test-anonymous-layer.geojson"
+    expected_file.parent.mkdir(parents=True)
+    expected_file.write_text('{"type":"FeatureCollection","features":[],"stale":true}')
+
+    main(
+        subdomain=arcgis_anonymous_server.subdomain,
+        service_id=arcgis_anonymous_server.service_id,
+        feature_id=arcgis_anonymous_server.feature_id,
+        layer_index_list=[0],
+        download_attachments=False,
+        output_format="geojson",
+        folder_name=folder_name,
+        attachment_root=str(asset_storage),
+    )
+
+    with open(expected_file) as f:
+        geojson_data = json.load(f)
+
+    assert "stale" not in geojson_data
+    assert len(geojson_data["features"]) == 1
+    assert geojson_data["features"][0]["properties"]["what_is_your_name"] == (
+        "Community mapper"
+    )


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-scripts-hub/issues/263.

@nicopace, I didn't realize it was the script that you yourself authored that needed a fix! 

If you want to make the fix directly next time and submit a PR, that is most welcome. (Not just limited to this script, I'm happy to work with you to get your fixes merged in, in accordance to the standards set in [`README.md#development`](https://github.com/ConservationMetrics/gc-scripts-hub/blob/main/README.md#development)

## What I changed and why

- Removed "if filename exists then don't skip download check" in anonymous arcgis download script.
- Added a test for this.

## How I convinced myself this is right

Tested in runtime.

## What I'm not doing here

- The `arcgis_feature_layer.py` script already matched this behavior. So it was only the `arcgis_download_feature_layer_anonymously.py` script that needed an adjustment.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None