### PR TITLE
Preserve non-Latin identifiers in normalize_identifier

### DIFF
--- a/f/common_logic/identifier_utils.py
+++ b/f/common_logic/identifier_utils.py
@@ -76,6 +76,11 @@ def normalize_identifier(
     names or file identifiers. It can optionally convert CamelCase into snake_case
     and force the identifier to start with a letter or underscore.
 
+    Latin-script accents are stripped to ASCII (e.g. ``ç`` → ``c``). Non-Latin
+    scripts (e.g. Thai, Chinese) are preserved — including combining marks such as
+    Thai tone/vowel signs — since PostgreSQL accepts them when identifiers are
+    properly quoted.
+
     Parameters
     ----------
     name : str
@@ -105,6 +110,8 @@ def normalize_identifier(
     '_123weirdname'
     >>> normalize_identifier("___name___")
     '___name___'
+    >>> normalize_identifier("สำรวจใหม่")
+    'สำรวจใหม่'
     See tests for more examples.
     """
     if maxlen < 1:
@@ -115,8 +122,16 @@ def normalize_identifier(
 
     original_name = name
 
+    # Strip Latin diacritics (é → e) via NFD, but keep non-Latin combining marks
+    # (Thai tone/vowel marks, Indic matras, etc.) which are also category Mn/Mc.
     normalized = unicodedata.normalize("NFD", name)
-    name = "".join(ch for ch in normalized if unicodedata.category(ch) != "Mn")
+    name = "".join(
+        ch
+        for ch in normalized
+        if not (
+            unicodedata.category(ch) == "Mn" and 0x0300 <= ord(ch) <= 0x036F
+        )
+    )
 
     if make_snake:
         name = camel_to_snake(name)
@@ -126,7 +141,14 @@ def normalize_identifier(
     else:
         name = re.sub(r"[ \-./]", "_", name)
 
-    name = re.sub(r"[^a-zA-Z0-9_]", "", name)
+    # Keep Unicode letters/digits, underscore, and remaining combining marks.
+    # ASCII-only filtering would collapse Thai/Chinese/etc. names to "_".
+    name = "".join(
+        ch
+        for ch in name
+        if ch.isalnum() or ch == "_" or unicodedata.category(ch) in {"Mn", "Mc", "Me"}
+    )
+    name = unicodedata.normalize("NFC", name)
 
     if not original_name.startswith("_"):
         name = name.lstrip("_")
@@ -135,7 +157,7 @@ def normalize_identifier(
 
     name = name if name.strip("_") else "_"
 
-    if ensure_leading_alpha and not re.match(r"^[a-zA-Z_]", name or ""):
+    if ensure_leading_alpha and not (name and (name[0].isalpha() or name[0] == "_")):
         name = "_" + (name or "")
 
     return name[:maxlen]

--- a/f/common_logic/tests/db_operations_test.py
+++ b/f/common_logic/tests/db_operations_test.py
@@ -8,6 +8,7 @@ from f.common_logic.db_operations import (
     fetch_tables_from_postgres,
     summarize_new_rows_updates_and_columns,
 )
+from f.common_logic.identifier_utils import normalize_identifier
 
 
 def test_fetch_tables_from_postgres(mock_db_connection):
@@ -544,3 +545,35 @@ def test_summarize_actual_kobotoolbox_csv_reupload(mock_db_dict):
     assert new_rows == 2  # Frederick and Occoquan
     assert updates == 0  # First 3 rows unchanged
     assert new_columns == 0  # NO new columns - CRITICAL TEST!
+
+
+def test_non_latin_table_and_column_names(mock_db_connection):
+    """Thai (and other non-Latin) dataset/column names must round-trip via StructuredDBWriter."""
+    table_name = normalize_identifier("สำรวจใหม่")
+    assert table_name == "สำรวจใหม่"
+
+    writer = StructuredDBWriter(mock_db_connection, table_name)
+    submissions = [
+        {"_id": "1", "อีเห็น": "sighting-a", "notes": "ok"},
+        {"_id": "2", "อีเห็น": "sighting-b", "notes": "ok"},
+    ]
+    writer.handle_output(submissions)
+
+    assert writer.table_name == "สำรวจใหม่"
+
+    with writer._get_conn() as pgconn:
+        columns = writer._inspect_schema(pgconn, writer.table_name)
+        assert "อีเห็น" in columns
+        assert "notes" in columns
+        assert "_" not in columns  # must not collapse Thai columns to "_"
+
+        with pgconn.cursor() as cursor:
+            cursor.execute(
+                'SELECT "_id", "อีเห็น", "notes" FROM "สำรวจใหม่" ORDER BY "_id"'
+            )
+            rows = cursor.fetchall()
+
+    assert rows == [
+        ("1", "sighting-a", "ok"),
+        ("2", "sighting-b", "ok"),
+    ]

--- a/f/common_logic/tests/identifier_utils_test.py
+++ b/f/common_logic/tests/identifier_utils_test.py
@@ -308,11 +308,38 @@ def test_normalize_identifier_sep_policy_param():
 
 def test_normalize_identifier_unicode_handling():
     """Test Unicode character handling and accent removal."""
-    # Test various accent types
+    # Latin accents strip to ASCII
     assert normalize_identifier("Vigilância Ambiental") == "vigilancia_ambiental"
     assert normalize_identifier("naïve café") == "naive_cafe"
     assert normalize_identifier("résumé") == "resume"
     assert normalize_identifier("Müller") == "muller"
+
+    # Non-Latin scripts are preserved (not collapsed to "_")
+    assert normalize_identifier("สำรวจใหม่") == "สำรวจใหม่"
+    assert normalize_identifier("อีเห็น") == "อีเห็น"
+    assert normalize_identifier("野外调查") == "野外调查"
+    assert normalize_identifier("สำรวจ ใหม่!") == "สำรวจ_ใหม่"
+
+
+def test_sanitize_sql_message__non_latin_column_names():
+    """CoMapeo Thai (and other non-Latin) field names must stay distinct SQL columns."""
+    message = {
+        "_id": "obs-1",
+        "อีเห็น": "sighting",
+        "สำรวจใหม่": "new survey",
+        "notes": "ok",
+    }
+    sql_message, mapping = sanitize_sql_message(message, {})
+    assert sql_message == {
+        "_id": "obs-1",
+        "อีเห็น": "sighting",
+        "สำรวจใหม่": "new survey",
+        "notes": "ok",
+    }
+    assert mapping["อีเห็น"] == "อีเห็น"
+    assert mapping["สำรวจใหม่"] == "สำรวจใหม่"
+    # Must not collapse all non-Latin keys onto "_"
+    assert set(sql_message) == {"_id", "อีเห็น", "สำรวจใหม่", "notes"}
 
 
 def test_normalize_identifier_complex_combinations():


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-scripts-hub/issues/262.

## What I changed and why

- Thai table/column names (e.g. `สำรวจใหม่`, `อีเห็น`) were becoming `_`. Same bug hit both tables (`normalize_identifier` on dataset/project names) and columns (`sanitize_sql_message` → `normalize_identifier`).
- Two filters were too aggressive:
  - Stripping **all** `Mn` (nonspacing) marks after NFD removed Thai tone/vowel signs (also `Mn`), not just Latin accents.
  - `[^a-zA-Z0-9_]` then dropped any remaining non-ASCII, so the name collapsed to `_`.
- Now only strip Latin combining diacritics (`Mn` in U+0300–U+036F, e.g. `ç` → `c`), keep other Unicode letters/digits/marks, and NFC-normalize so Thai stays composed. `ensure_leading_alpha` also accepts Unicode letters.
- Added tests for Thai table/column round-trips.

## How I convinced myself this is right

I tested in runtime (c.f. #262)

## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

I conferred with Cursor Opus 4.8 to make the plan and Cursor Grok 4.5 did implementation.