### PR TITLE
Modify KoboToolbox label lookup table to include `question_name` column

### DIFF
--- a/f/connectors/kobotoolbox/README.md
+++ b/f/connectors/kobotoolbox/README.md
@@ -8,15 +8,16 @@ The script creates a secondary table named `<table_name>__labels` to store quest
 
 Each row represents one label for a form element (from either the `survey` or `choices` section), with the following structure: 
 
-| Column     | Type    | Description                                                                 |
-|------------|---------|-----------------------------------------------------------------------------|
-| `type`     | TEXT    | Either `"survey"` or `"choices"` indicating the form section               |
-| `name`     | TEXT    | The name of the form element (question or choice)                          |
-| `language` | TEXT    | The language of the label (e.g., `"en"`, `"es"`, `"pt"`)                    |
-| `label`    | TEXT    | The label text in the specified language                                   |
-| `_id`      | TEXT    | Deterministic hash based on the row content (used as a unique key)         |
+| Column          | Type    | Description                                                                 |
+|-----------------|---------|-----------------------------------------------------------------------------|
+| `type`          | TEXT    | Either `"survey"` or `"choices"` indicating the form section               |
+| `question_name` | TEXT    | For choices: the survey question that uses this choice list. `NULL` for survey rows (and orphan choices with no referencing question). When multiple questions share a list, choice rows are duplicated once per question. |
+| `name`          | TEXT    | The name of the form element (question or choice)                          |
+| `language`      | TEXT    | The language of the label (e.g., `"en"`, `"es"`, `"pt"`)                    |
+| `label`         | TEXT    | The label text in the specified language                                   |
+| `_id`           | TEXT    | Deterministic hash based on the row content (used as a unique key)         |
 
-This table can be used for rendering field translations in downstream clients, selecting the appropriate label by language, or falling back gracefully when a translation is missing.
+This table can be used for rendering field translations in downstream clients, selecting the appropriate label by language, or falling back gracefully when a translation is missing. Choice value lookups should join on both `question_name` and `name` so reused raw values (e.g. shared numeric scales) resolve to the correct label.
 
 ## Nested Data Flattening (repeat groups & matrices)
 

--- a/f/connectors/kobotoolbox/kobotoolbox_responses.py
+++ b/f/connectors/kobotoolbox/kobotoolbox_responses.py
@@ -155,6 +155,10 @@ def extract_form_labels(form_metadata):
 
     If no labels are found in the metadata, returns an empty list.
 
+    Choice rows are expanded once per survey question that references their
+    ``list_name`` via ``select_from_list_name``, so reused choice values remain
+    unambiguous when joined on ``question_name``.
+
     Parameters
     ----------
     form_metadata : dict
@@ -166,52 +170,90 @@ def extract_form_labels(form_metadata):
         A list of dictionaries, each representing a label for a form item with the following keys:
         - '_id': A unique identifier for the item-language tuple, generated using an MD5 hash.
         - 'type': The type of the item, either 'survey' or 'choices'.
+        - 'question_name': For choices, the survey question that uses this choice list;
+          ``None`` for survey rows (and orphan choices with no referencing question).
         - 'name': The name of the form item.
         - 'language': The language code of the label (e.g., 'en', 'es').
         - 'label': The label text in the specified language.
     """
     content = form_metadata.get("content", {})
     translations = content.get("translations", [])
+    survey_items = content.get("survey", [])
+    choice_items = content.get("choices", [])
+
+    list_to_questions = {}
+    for item in survey_items:
+        list_name = item.get("select_from_list_name")
+        if not list_name:
+            continue
+        question_name = item.get("name", item.get("$autoname"))
+        list_to_questions.setdefault(list_name, []).append(question_name)
+
+    def _append_row(rows, *, type_, question_name, name, language, label):
+        row = {
+            "type": type_,
+            "question_name": question_name,
+            "name": name,
+            "language": language,
+            "label": label,
+        }
+        hash_input = json.dumps(row, sort_keys=True).encode("utf-8")
+        row["_id"] = hashlib.md5(hash_input).hexdigest()
+        rows.append(row)
+
+    def _emit_item_labels(rows, *, section, item, language, label):
+        name = item.get("name", item.get("$autoname"))
+        if section == "survey":
+            _append_row(
+                rows,
+                type_=section,
+                question_name=None,
+                name=name,
+                language=language,
+                label=label,
+            )
+            return
+
+        question_names = list_to_questions.get(item.get("list_name"), [None])
+        for question_name in question_names:
+            _append_row(
+                rows,
+                type_=section,
+                question_name=question_name,
+                name=name,
+                language=language,
+                label=label,
+            )
 
     rows = []
 
     if not translations or translations == [None]:
-        # Single-language form, only one label per item
-        for section in ["survey", "choices"]:
-            for item in content.get(section, []):
+        for section, items in (("survey", survey_items), ("choices", choice_items)):
+            for item in items:
                 label = item.get("label", [None])[0]
-                row = {
-                    "type": section,
-                    "name": item.get("name", item.get("$autoname")),
-                    "language": None,
-                    "label": label,
-                }
-                hash_input = json.dumps(row, sort_keys=True).encode("utf-8")
-                row["_id"] = hashlib.md5(hash_input).hexdigest()
-                rows.append(row)
+                _emit_item_labels(
+                    rows, section=section, item=item, language=None, label=label
+                )
         return rows
 
-    # Parse language codes from translations (assumes format "Name (xx)")
     lang_codes = [
         lang[lang.find("(") + 1 : lang.find(")")]
         for lang in translations
         if isinstance(lang, str) and "(" in lang and ")" in lang
     ]
 
-    for section in ["survey", "choices"]:
-        for item in content.get(section, []):
+    for section, items in (("survey", survey_items), ("choices", choice_items)):
+        for item in items:
             labels = item.get("label", [])
             for i, code in enumerate(lang_codes):
                 if i < len(labels):
-                    row = {
-                        "type": section,
-                        "name": item.get("name", item.get("$autoname")),
-                        "language": code,
-                        "label": labels[i],
-                    }
-                    hash_input = json.dumps(row, sort_keys=True).encode("utf-8")
-                    row["_id"] = hashlib.md5(hash_input).hexdigest()
-                    rows.append(row)
+                    _emit_item_labels(
+                        rows,
+                        section=section,
+                        item=item,
+                        language=code,
+                        label=labels[i],
+                    )
 
     return rows
 

--- a/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
+++ b/f/connectors/kobotoolbox/tests/kobotoolbox_responses_test.py
@@ -4,10 +4,188 @@ from pathlib import Path
 import psycopg
 
 from f.connectors.kobotoolbox.kobotoolbox_responses import (
+    extract_form_labels,
     flatten_kobotoolbox_submission,
     main,
     transform_kobotoolbox_form_data,
 )
+
+
+def _label_rows_by(*, rows, **filters):
+    return [
+        row
+        for row in rows
+        if all(row.get(key) == value for key, value in filters.items())
+    ]
+
+
+def test_extract_form_labels__survey_question_name_is_none():
+    metadata = {
+        "content": {
+            "survey": [
+                {
+                    "name": "tree_height",
+                    "type": "integer",
+                    "label": ["Tree height"],
+                }
+            ],
+            "choices": [],
+            "translations": [None],
+        }
+    }
+
+    rows = extract_form_labels(metadata)
+    survey = _label_rows_by(rows=rows, type="survey", name="tree_height")
+    assert len(survey) == 1
+    assert survey[0]["question_name"] is None
+    assert survey[0]["label"] == "Tree height"
+
+
+def test_extract_form_labels__choice_scoped_to_question():
+    metadata = {
+        "content": {
+            "survey": [
+                {
+                    "name": "I_like_this_tree_because",
+                    "type": "select_multiple",
+                    "select_from_list_name": "tree_reasons",
+                    "label": ["Why do you like this tree?"],
+                }
+            ],
+            "choices": [
+                {
+                    "list_name": "tree_reasons",
+                    "name": "shade",
+                    "label": ["Shade"],
+                }
+            ],
+            "translations": [None],
+        }
+    }
+
+    rows = extract_form_labels(metadata)
+    choices = _label_rows_by(rows=rows, type="choices", name="shade")
+    assert len(choices) == 1
+    assert choices[0]["question_name"] == "I_like_this_tree_because"
+    assert choices[0]["label"] == "Shade"
+
+
+def test_extract_form_labels__disambiguates_reused_choice_names():
+    metadata = {
+        "content": {
+            "survey": [
+                {
+                    "name": "Traditional_knowledge",
+                    "type": "select_one",
+                    "select_from_list_name": "knowledge_scale",
+                    "label": ["Traditional knowledge"],
+                },
+                {
+                    "name": "Frequency",
+                    "type": "select_one",
+                    "select_from_list_name": "frequency_scale",
+                    "label": ["Frequency"],
+                },
+            ],
+            "choices": [
+                {
+                    "list_name": "knowledge_scale",
+                    "name": "2",
+                    "label": ["In the past"],
+                },
+                {
+                    "list_name": "frequency_scale",
+                    "name": "2",
+                    "label": ["Frequently"],
+                },
+            ],
+            "translations": [None],
+        }
+    }
+
+    rows = extract_form_labels(metadata)
+    knowledge = _label_rows_by(
+        rows=rows, type="choices", name="2", question_name="Traditional_knowledge"
+    )
+    frequency = _label_rows_by(
+        rows=rows, type="choices", name="2", question_name="Frequency"
+    )
+    assert len(knowledge) == 1
+    assert knowledge[0]["label"] == "In the past"
+    assert len(frequency) == 1
+    assert frequency[0]["label"] == "Frequently"
+    assert knowledge[0]["_id"] != frequency[0]["_id"]
+
+
+def test_extract_form_labels__shared_list_duplicates_per_question():
+    metadata = {
+        "content": {
+            "survey": [
+                {
+                    "name": "condition_a",
+                    "type": "select_one",
+                    "select_from_list_name": "yes_no",
+                    "label": ["Condition A"],
+                },
+                {
+                    "name": "condition_b",
+                    "type": "select_one",
+                    "select_from_list_name": "yes_no",
+                    "label": ["Condition B"],
+                },
+            ],
+            "choices": [
+                {"list_name": "yes_no", "name": "yes", "label": ["Yes"]},
+            ],
+            "translations": [None],
+        }
+    }
+
+    rows = extract_form_labels(metadata)
+    choices = _label_rows_by(rows=rows, type="choices", name="yes")
+    assert {row["question_name"] for row in choices} == {
+        "condition_a",
+        "condition_b",
+    }
+    assert all(row["label"] == "Yes" for row in choices)
+    assert len({row["_id"] for row in choices}) == 2
+
+
+def test_extract_form_labels__multilang_includes_question_name():
+    metadata = {
+        "content": {
+            "survey": [
+                {
+                    "name": "I_like_this_tree_because",
+                    "type": "select_multiple",
+                    "select_from_list_name": "tree_reasons",
+                    "label": ["Why?", "¿Por qué?"],
+                }
+            ],
+            "choices": [
+                {
+                    "list_name": "tree_reasons",
+                    "name": "shade",
+                    "label": ["Shade", "Sombra"],
+                }
+            ],
+            "translations": ["English (en)", "Spanish (es)"],
+        }
+    }
+
+    rows = extract_form_labels(metadata)
+    en = _label_rows_by(
+        rows=rows, type="choices", name="shade", language="en"
+    )
+    es = _label_rows_by(
+        rows=rows, type="choices", name="shade", language="es"
+    )
+    assert len(en) == 1
+    assert en[0]["question_name"] == "I_like_this_tree_because"
+    assert en[0]["label"] == "Shade"
+    assert len(es) == 1
+    assert es[0]["question_name"] == "I_like_this_tree_because"
+    assert es[0]["label"] == "Sombra"
 
 
 def test_script_e2e(koboserver, pg_database, tmp_path):
@@ -72,11 +250,11 @@ def test_script_e2e(koboserver, pg_database, tmp_path):
             # Verify specific translations for survey items
             cursor.execute(
                 f"""
-                SELECT label FROM {table_name}__labels 
+                SELECT label, question_name FROM {table_name}__labels 
                 WHERE name = 'Record_your_current_location' AND language = 'en'
                 """
             )
-            assert cursor.fetchone()[0] == "Record your current location"
+            assert cursor.fetchone() == ("Record your current location", None)
 
             cursor.execute(
                 f"""
@@ -107,19 +285,22 @@ def test_script_e2e(koboserver, pg_database, tmp_path):
             # Verify specific translations for choice items
             cursor.execute(
                 f"""
-                SELECT label FROM {table_name}__labels 
+                SELECT label, question_name FROM {table_name}__labels 
                 WHERE name = 'shade' AND language = 'es'
                 """
             )
-            assert cursor.fetchone()[0] == "Sombra"
+            assert cursor.fetchone() == ("Sombra", "I_like_this_tree_because")
 
             cursor.execute(
                 f"""
-                SELECT label FROM {table_name}__labels 
+                SELECT label, question_name FROM {table_name}__labels 
                 WHERE name = 'wildlife_habitat' AND language = 'pt'
                 """
             )
-            assert cursor.fetchone()[0] == "Habitat da vida selvagem"
+            assert cursor.fetchone() == (
+                "Habitat da vida selvagem",
+                "I_like_this_tree_because",
+            )
 
             # Check that the type is set for survey / choice items
             cursor.execute(
@@ -157,9 +338,19 @@ def test_script_e2e__no_translations(koboserver_no_translations, pg_database, tm
             cursor.execute(f"SELECT COUNT(*) FROM {table_name}__labels")
             assert cursor.fetchone()[0] == 8
             cursor.execute(
-                f"SELECT label FROM {table_name}__labels WHERE name = 'Record_your_current_location'"
+                f"""
+                SELECT label, question_name FROM {table_name}__labels
+                WHERE name = 'Record_your_current_location'
+                """
             )
-            assert cursor.fetchone() == ("Record your current location",)
+            assert cursor.fetchone() == ("Record your current location", None)
+            cursor.execute(
+                f"""
+                SELECT label, question_name FROM {table_name}__labels
+                WHERE name = 'shade'
+                """
+            )
+            assert cursor.fetchone() == ("Shade", "I_like_this_tree_because")
 
 
 def test_script_e2e__no_submissions(koboserver_no_submissions, pg_database, tmp_path):


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-scripts-hub/issues/264.

## What I changed and why

- **`question_name` on `__labels`** — Choice values like `0`/`1`/`2` are reused across questions with different meanings. Storing only `name` made label joins ambiguous.
- **`extract_form_labels`** — Choice rows now include the select question that owns their list. Shared lists are duplicated once per question so e.g. Superset can join on `question_name` + `name`.

## How I convinced myself this is right

See See https://github.com/ConservationMetrics/gc-docs/issues/47#issuecomment-5029372360 for context.

## What I'm not doing here

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->
