### PR TITLE
Add a Mapbox script to download, and reconstruct, vector tiles

### DIFF
--- a/f/connectors/mapbox/README.md
+++ b/f/connectors/mapbox/README.md
@@ -1,3 +1,7 @@
+# Mapbox connectors
+
+Scripts for working with Mapbox tilesets and vector tile data.
+
 # `mapbox_create_or_update_tileset`: Create or Update a Mapbox Tileset
 
 This script uses the Mapbox Tiling Service (MTS) to create **or** update a Mapbox tileset from a GeoJSON file by:
@@ -29,7 +33,7 @@ This script is intended for workflows where a GeoJSON dataset is updated regular
 
 ## Mapbox Secret Access Token
 
-For the scripts to work, you need to provide a Mapbox secret access token with scope to work with tilesets. You can create a new secret access token in Mapbox Studio by:
+For this script to work, you need to provide a Mapbox secret access token with scope to work with tilesets. You can create a new secret access token in Mapbox Studio by:
 
 1. Navigating to **Admin >  Tokens**
 2. Clicking **+ Create a token**
@@ -46,7 +50,7 @@ When creating a tileset, a [tileset recipe](https://docs.mapbox.com/mapbox-tilin
 In this script:
 
 - The minimum zoom level is hard-coded to `0`.
-- The maximum zoom level is configurable via the `max_zoom` parameter (default: `11`, valid range: `0-16`).
+- The maximum zoom level is configurable via the `max_zoom` parameter (default: `11`, string pattern-limited to `0-16`).
 - The `max_zoom` parameter is ignored when updating an existing tileset.
 
 > [!TIP]
@@ -69,3 +73,62 @@ This script uses the following Mapbox Tiling Service API endpoints:
 - **Windmill Flow**: We could consider chaining this script to another connector (like the [ArcGIS Download Feature Layer script](../arcgis/README.md)) to create a flow that:
   - downloads and stores a feature layer from ArcGIS Online
   - publishes the tileset to Mapbox.
+
+# `mapbox_download_vector_tiles`: Download Vector Tiles to GeoJSON
+
+Download Mapbox vector tiles for a bounding box into a local cache, then convert them into a single GeoJSON FeatureCollection.
+
+Flow:
+
+1. Plan the tile grid for the requested bbox and zoom (with a hard zoom cap for quota safety).
+2. If `dry_run` is true, return the plan and stop — no network requests.
+3. Otherwise download uncached tiles, convert cached PBFs to GeoJSON (optionally reconstructing clipped features), and write the result to the datalake.
+
+## Intended use case
+
+Use this when you need vector features from an existing Mapbox tileset (for example `mapbox.mapbox-streets-v8` or a custom tileset) as GeoJSON for analysis, archival, or a downstream workflow:
+
+1. Run with `dry_run=true` to confirm the tile count is within your Mapbox API budget.
+2. Run again with `dry_run=false` to download and convert into GeoJSON under the datalake.
+3. Optionally chain to `mapbox_create_or_update_tileset` if you want to republish a derived tileset.
+
+## Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `mapbox` | *(required)* | Mapbox credentials resource. Only `access_token` is used. |
+| `bbox` | *(required)* | Bounding box as `minlon,minlat,maxlon,maxlat` (WGS84 degrees). |
+| `tileset` | *(required)* | Mapbox tileset id (e.g. `mapbox.mapbox-streets-v8`). |
+| `zoom` | `12` | Zoom level of the tile grid (string pattern-limited to 0–14). |
+| `reconstruct_column` | `""` | Feature property used to reconstruct features clipped across tile boundaries. Empty disables reconstruction. |
+| `output_filename` | `my_filename` | Base name for the GeoJSON file and tile cache directory. |
+| `attachment_root` | `/persistent-storage/datalake/mapbox_vector_tiles` | Datalake directory for output. |
+| `delete_tiles` | `true` | After a successful GeoJSON write, delete the tile cache so only the GeoJSON remains. Set `false` to keep tiles for faster re-runs. |
+| `dry_run` | `false` | Return the download plan without fetching or writing GeoJSON. |
+
+### Output paths
+
+- Tile cache: `{attachment_root}/{output_filename}/tiles/{z}/{x}/{y}.pbf`
+- GeoJSON: `{attachment_root}/{output_filename}.geojson`
+
+Cached tiles are skipped on re-run (when `delete_tiles` is false). Empty cells are cached as zero-byte markers for both HTTP 204 (blank tile) and HTTP 404 `Tile not found` (sparse coverage / outside the tileset extent). Other failures (auth, rate limit, missing tileset, etc.) are not cached, so re-running retries only those.
+
+## Access token
+
+Unlike `mapbox_create_or_update_tileset`, this script only needs a token that can read vector tiles. A **public** token (`pk.ey...`) with access to the target tilesets is sufficient; a secret token also works. Create or copy a token from **Admin > Tokens** in Mapbox Studio.
+
+## Quota guardrails
+
+Vector tile requests count against Mapbox API quota:
+
+- **Dry-run** — inspect `tile_count` / `to_fetch_count` before spending quota.
+- **Local cache** — already-downloaded tiles are never re-requested.
+- **Zoom limit** — tile count grows ~4× per zoom level; `zoom` is capped at 14 in the Windmill schema.
+
+> [!TIP]
+>
+> Use [OpenStreetMap's Zoom Levels guide](https://wiki.openstreetmap.org/wiki/Zoom_levels) to pick an appropriate zoom. A tileset only contains data up to its own `maxzoom`; higher zooms often mean more requests with no extra detail.
+
+## Endpoints
+
+- [Retrieve vector tiles](https://docs.mapbox.com/api/maps/vector-tiles/)

--- a/f/connectors/mapbox/README.md
+++ b/f/connectors/mapbox/README.md
@@ -86,11 +86,10 @@ Flow:
 
 ## Intended use case
 
-Use this when you need vector features from an existing Mapbox tileset (for example `mapbox.mapbox-streets-v8` or a custom tileset) as GeoJSON for analysis, archival, or a downstream workflow:
+Use this when you need vector features from a Mapbox tileset as GeoJSON for analysis, archival, or a downstream workflow:
 
 1. Run with `dry_run=true` to confirm the tile count is within your Mapbox API budget.
 2. Run again with `dry_run=false` to download and convert into GeoJSON under the datalake.
-3. Optionally chain to `mapbox_create_or_update_tileset` if you want to republish a derived tileset.
 
 ## Parameters
 
@@ -99,10 +98,10 @@ Use this when you need vector features from an existing Mapbox tileset (for exam
 | `mapbox` | *(required)* | Mapbox credentials resource. Only `access_token` is used. |
 | `bbox` | *(required)* | Bounding box as `minlon,minlat,maxlon,maxlat` (WGS84 degrees). |
 | `tileset` | *(required)* | Mapbox tileset id (e.g. `mapbox.mapbox-streets-v8`). |
-| `zoom` | `12` | Zoom level of the tile grid (string pattern-limited to 0–14). |
+| `zoom` | `12` | Zoom level of the tile grid (string pattern, limited to 0-14). |
 | `reconstruct_column` | `""` | Feature property used to reconstruct features clipped across tile boundaries. Empty disables reconstruction. |
 | `output_filename` | `my_filename` | Base name for the GeoJSON file and tile cache directory. |
-| `attachment_root` | `/persistent-storage/datalake/mapbox_vector_tiles` | Datalake directory for output. |
+| `attachment_root` | `/persistent-storage/datalake/mapbox` | Datalake directory for output. |
 | `delete_tiles` | `true` | After a successful GeoJSON write, delete the tile cache so only the GeoJSON remains. Set `false` to keep tiles for faster re-runs. |
 | `dry_run` | `false` | Return the download plan without fetching or writing GeoJSON. |
 

--- a/f/connectors/mapbox/mapbox_create_or_update_tileset.py
+++ b/f/connectors/mapbox/mapbox_create_or_update_tileset.py
@@ -25,7 +25,7 @@ def main(
     tileset_id: str,
     file_location: str,
     attachment_root: str = "/persistent-storage/datalake",
-    max_zoom: int = 11,
+    max_zoom: str = "11",
 ) -> dict:
     """
     Create or update a Mapbox tileset from a GeoJSON file.
@@ -41,6 +41,7 @@ def main(
 
     _assert_secret_access_token(access_token)
     validate_identifier(tileset_id, type="mapbox_tileset_id")
+    max_zoom_level = _parse_max_zoom(max_zoom)
 
     source_path = Path(attachment_root) / file_location
     if not source_path.is_file():
@@ -60,7 +61,9 @@ def main(
     source_result = _create_tileset_source(
         username, access_token, tileset_id, source_path
     )
-    tileset_result = _create_tileset(username, access_token, tileset_id, max_zoom)
+    tileset_result = _create_tileset(
+        username, access_token, tileset_id, max_zoom_level
+    )
     publish_result = _publish_tileset(username, access_token, tileset_id)
     return {
         "action": "create",
@@ -68,6 +71,33 @@ def main(
         "tileset": tileset_result,
         "publish": publish_result,
     }
+
+
+def _parse_max_zoom(raw: str | int) -> int:
+    """Parse and validate a max zoom level in the range 0-16.
+
+    Parameters
+    ----------
+    raw : str or int
+        Max zoom from the Windmill form (string) or tests (int).
+
+    Returns
+    -------
+    int
+        Max zoom between 0 and 16 inclusive.
+
+    Raises
+    ------
+    ValueError
+        If the value is not an integer in 0-16.
+    """
+    try:
+        max_zoom = int(raw)
+    except (TypeError, ValueError) as e:
+        raise ValueError(f"max_zoom must be an integer 0-16, got {raw!r}") from e
+    if not 0 <= max_zoom <= 16:
+        raise ValueError(f"max_zoom must be between 0 and 16, got {max_zoom}")
+    return max_zoom
 
 
 def _assert_secret_access_token(access_token: str) -> None:

--- a/f/connectors/mapbox/mapbox_create_or_update_tileset.py
+++ b/f/connectors/mapbox/mapbox_create_or_update_tileset.py
@@ -41,7 +41,7 @@ def main(
 
     _assert_secret_access_token(access_token)
     validate_identifier(tileset_id, type="mapbox_tileset_id")
-    max_zoom_level = _parse_max_zoom(max_zoom)
+    max_zoom = int(max_zoom)
 
     source_path = Path(attachment_root) / file_location
     if not source_path.is_file():
@@ -61,9 +61,7 @@ def main(
     source_result = _create_tileset_source(
         username, access_token, tileset_id, source_path
     )
-    tileset_result = _create_tileset(
-        username, access_token, tileset_id, max_zoom_level
-    )
+    tileset_result = _create_tileset(username, access_token, tileset_id, max_zoom)
     publish_result = _publish_tileset(username, access_token, tileset_id)
     return {
         "action": "create",
@@ -71,33 +69,6 @@ def main(
         "tileset": tileset_result,
         "publish": publish_result,
     }
-
-
-def _parse_max_zoom(raw: str | int) -> int:
-    """Parse and validate a max zoom level in the range 0-16.
-
-    Parameters
-    ----------
-    raw : str or int
-        Max zoom from the Windmill form (string) or tests (int).
-
-    Returns
-    -------
-    int
-        Max zoom between 0 and 16 inclusive.
-
-    Raises
-    ------
-    ValueError
-        If the value is not an integer in 0-16.
-    """
-    try:
-        max_zoom = int(raw)
-    except (TypeError, ValueError) as e:
-        raise ValueError(f"max_zoom must be an integer 0-16, got {raw!r}") from e
-    if not 0 <= max_zoom <= 16:
-        raise ValueError(f"max_zoom must be between 0 and 16, got {max_zoom}")
-    return max_zoom
 
 
 def _assert_secret_access_token(access_token: str) -> None:

--- a/f/connectors/mapbox/mapbox_create_or_update_tileset.script.yaml
+++ b/f/connectors/mapbox/mapbox_create_or_update_tileset.script.yaml
@@ -39,14 +39,13 @@ schema:
       default: null
       format: resource-mapbox
     max_zoom:
-      type: integer
+      type: string
       description: >-
-        Maximum zoom level for a newly-created tileset. Valid range is 0-16.
-        (Ignored when updating an existing tileset.)
-      default: 11
-      maximum: 16
-      minimum: 0
-      originalType: integer
+        Maximum zoom level for a newly-created tileset (0-16). Ignored when
+        updating an existing tileset.
+      default: '11'
+      originalType: string
+      pattern: '^([0-9]|1[0-6])$'
     tileset_id:
       type: string
       description: The tileset ID (without the username prefix).

--- a/f/connectors/mapbox/mapbox_download_vector_tiles.py
+++ b/f/connectors/mapbox/mapbox_download_vector_tiles.py
@@ -51,7 +51,7 @@ def main(
         Mapbox tileset id (e.g. ``mapbox.mapbox-streets-v8``).
     zoom : str, optional
         Zoom level for the tile grid as a string ``"0"``-``"14"`` (default
-        ``"12"``). Validated by the Windmill script schema pattern.
+        ``"12"``). Validated by the Windmill script schema pattern (which is why it's a string).
     reconstruct_column : str, optional
         Feature property used to reconstruct features clipped across tile
         boundaries. Empty string disables reconstruction.
@@ -76,17 +76,17 @@ def main(
     if not tileset.strip():
         raise ValueError("tileset is required")
 
-    zoom_level = _parse_zoom(zoom)
+    zoom = int(zoom)
     parsed_bbox = _parse_bbox(bbox)
 
     tiles_dir = Path(attachment_root) / output_filename / "tiles"
-    tiles = list(mercantile.tiles(*parsed_bbox, zooms=[zoom_level]))
+    tiles = list(mercantile.tiles(*parsed_bbox, zooms=[zoom]))
     to_fetch = [t for t in tiles if not _tile_path(tiles_dir, t).is_file()]
     cached_count = len(tiles) - len(to_fetch)
 
     plan = {
         "dry_run": dry_run,
-        "zoom": zoom_level,
+        "zoom": zoom,
         "bbox": parsed_bbox,
         "tileset": tileset,
         "tile_count": len(tiles),
@@ -95,7 +95,7 @@ def main(
     }
     logger.info(
         "Bounding box at zoom %s: %s tiles (%s cached, %s to download).",
-        zoom_level,
+        zoom,
         len(tiles),
         cached_count,
         len(to_fetch),
@@ -116,7 +116,7 @@ def main(
             "Re-run to retry failed tiles; cached tiles are skipped."
         )
 
-    features = _process_tiles(tiles_dir, zoom_level, reconstruct_column or None)
+    features = _process_tiles(tiles_dir, zoom, reconstruct_column or None)
     collection = {"type": "FeatureCollection", "features": features}
     save_data_to_file(
         collection,
@@ -154,33 +154,6 @@ def main(
     }
 
 
-def _parse_zoom(raw: str | int) -> int:
-    """Parse and validate a zoom level in the range 0-14.
-
-    Parameters
-    ----------
-    raw : str or int
-        Zoom level from the Windmill form (string) or tests (int).
-
-    Returns
-    -------
-    int
-        Zoom level between 0 and 14 inclusive.
-
-    Raises
-    ------
-    ValueError
-        If the value is not an integer in 0-14.
-    """
-    try:
-        zoom = int(raw)
-    except (TypeError, ValueError) as e:
-        raise ValueError(f"zoom must be an integer 0-14, got {raw!r}") from e
-    if not 0 <= zoom <= 14:
-        raise ValueError(f"zoom must be between 0 and 14, got {zoom}")
-    return zoom
-
-
 def _parse_bbox(raw: str) -> tuple[float, float, float, float]:
     """Parse a ``minlon,minlat,maxlon,maxlat`` string into four floats.
 
@@ -202,9 +175,7 @@ def _parse_bbox(raw: str) -> tuple[float, float, float, float]:
     try:
         parts = [float(p) for p in raw.split(",")]
     except ValueError as e:
-        raise ValueError(
-            f"expected four comma-separated numbers, got {raw!r}"
-        ) from e
+        raise ValueError(f"expected four comma-separated numbers, got {raw!r}") from e
     if len(parts) != 4:
         raise ValueError(
             f"expected 4 values (minlon,minlat,maxlon,maxlat), got {len(parts)}: {raw!r}"

--- a/f/connectors/mapbox/mapbox_download_vector_tiles.py
+++ b/f/connectors/mapbox/mapbox_download_vector_tiles.py
@@ -1,0 +1,455 @@
+# requirements:
+# requests~=2.32
+# mercantile
+# vt2geojson
+# shapely
+
+import logging
+import shutil
+from pathlib import Path
+from typing import TypedDict
+
+import mercantile
+import requests
+from vt2geojson.tools import vt_bytes_to_geojson
+
+from f.common_logic.file_operations import save_data_to_file
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+_REQUEST_TIMEOUT_S = 30
+
+
+# https://hub.windmill.dev/resource_types/340/mapbox_credentials
+class mapbox(TypedDict):
+    username: str
+    access_token: str
+
+
+def main(
+    mapbox: mapbox,
+    bbox: str,
+    tileset: str,
+    zoom: str = "12",
+    reconstruct_column: str = "",
+    output_filename: str = "my_filename",
+    attachment_root: str = "/persistent-storage/datalake/mapbox_vector_tiles",
+    delete_tiles: bool = True,
+    dry_run: bool = False,
+) -> dict:
+    """Download Mapbox vector tiles and convert them to a GeoJSON file.
+
+    Parameters
+    ----------
+    mapbox : mapbox
+        Mapbox credentials resource. Only ``access_token`` is used (public or
+        secret token). ``username`` is ignored.
+    bbox : str
+        Bounding box as ``minlon,minlat,maxlon,maxlat`` in WGS84 degrees.
+    tileset : str
+        Mapbox tileset id (e.g. ``mapbox.mapbox-streets-v8``).
+    zoom : str, optional
+        Zoom level for the tile grid as a string ``"0"``-``"14"`` (default
+        ``"12"``). Validated by the Windmill script schema pattern.
+    reconstruct_column : str, optional
+        Feature property used to reconstruct features clipped across tile
+        boundaries. Empty string disables reconstruction.
+    output_filename : str, optional
+        Base name for the GeoJSON file and tile cache directory.
+    attachment_root : str, optional
+        Datalake directory for output.
+    delete_tiles : bool, optional
+        If True (default), delete the tile cache after a successful GeoJSON
+        write so only the GeoJSON remains.
+    dry_run : bool, optional
+        If True, return the download plan without fetching or processing tiles.
+
+    Returns
+    -------
+    dict
+        Dry-run plan or full-run result with download and feature counts.
+    """
+    access_token = mapbox["access_token"]
+    if not access_token:
+        raise ValueError("mapbox.access_token is required")
+    if not tileset.strip():
+        raise ValueError("tileset is required")
+
+    zoom_level = _parse_zoom(zoom)
+    parsed_bbox = _parse_bbox(bbox)
+
+    tiles_dir = Path(attachment_root) / output_filename / "tiles"
+    tiles = list(mercantile.tiles(*parsed_bbox, zooms=[zoom_level]))
+    to_fetch = [t for t in tiles if not _tile_path(tiles_dir, t).is_file()]
+    cached_count = len(tiles) - len(to_fetch)
+
+    plan = {
+        "dry_run": dry_run,
+        "zoom": zoom_level,
+        "bbox": parsed_bbox,
+        "tileset": tileset,
+        "tile_count": len(tiles),
+        "cached_count": cached_count,
+        "to_fetch_count": len(to_fetch),
+    }
+    logger.info(
+        "Bounding box at zoom %s: %s tiles (%s cached, %s to download).",
+        zoom_level,
+        len(tiles),
+        cached_count,
+        len(to_fetch),
+    )
+
+    if dry_run:
+        return plan
+
+    downloaded, failed = _download_tiles(
+        tileset=tileset,
+        access_token=access_token,
+        tiles_dir=tiles_dir,
+        to_fetch=to_fetch,
+    )
+    if failed:
+        raise RuntimeError(
+            f"Failed to download {failed} of {len(to_fetch)} tiles. "
+            "Re-run to retry failed tiles; cached tiles are skipped."
+        )
+
+    features = _process_tiles(tiles_dir, zoom_level, reconstruct_column or None)
+    collection = {"type": "FeatureCollection", "features": features}
+    save_data_to_file(
+        collection,
+        output_filename,
+        attachment_root,
+        file_type="geojson",
+    )
+    output_path = str(Path(attachment_root).resolve() / f"{output_filename}.geojson")
+
+    tiles_deleted = False
+    if delete_tiles:
+        logger.info(
+            "Deleting tile cache at %s after successful GeoJSON write.",
+            tiles_dir,
+        )
+        shutil.rmtree(tiles_dir)
+        parent = tiles_dir.parent
+        if parent.is_dir() and not any(parent.iterdir()):
+            parent.rmdir()
+        tiles_deleted = True
+    else:
+        logger.info(
+            "Keeping tile cache at %s on the datalake.",
+            tiles_dir,
+        )
+
+    return {
+        **plan,
+        "tiles_downloaded": downloaded,
+        "tiles_failed": failed,
+        "tiles_cached_skipped": cached_count,
+        "feature_count": len(features),
+        "output_path": output_path,
+        "tiles_deleted": tiles_deleted,
+    }
+
+
+def _parse_zoom(raw: str | int) -> int:
+    """Parse and validate a zoom level in the range 0-14.
+
+    Parameters
+    ----------
+    raw : str or int
+        Zoom level from the Windmill form (string) or tests (int).
+
+    Returns
+    -------
+    int
+        Zoom level between 0 and 14 inclusive.
+
+    Raises
+    ------
+    ValueError
+        If the value is not an integer in 0-14.
+    """
+    try:
+        zoom = int(raw)
+    except (TypeError, ValueError) as e:
+        raise ValueError(f"zoom must be an integer 0-14, got {raw!r}") from e
+    if not 0 <= zoom <= 14:
+        raise ValueError(f"zoom must be between 0 and 14, got {zoom}")
+    return zoom
+
+
+def _parse_bbox(raw: str) -> tuple[float, float, float, float]:
+    """Parse a ``minlon,minlat,maxlon,maxlat`` string into four floats.
+
+    Parameters
+    ----------
+    raw : str
+        Comma-separated bounding box string.
+
+    Returns
+    -------
+    tuple of float
+        ``(minlon, minlat, maxlon, maxlat)``.
+
+    Raises
+    ------
+    ValueError
+        If the string is malformed or the box is invalid.
+    """
+    try:
+        parts = [float(p) for p in raw.split(",")]
+    except ValueError as e:
+        raise ValueError(
+            f"expected four comma-separated numbers, got {raw!r}"
+        ) from e
+    if len(parts) != 4:
+        raise ValueError(
+            f"expected 4 values (minlon,minlat,maxlon,maxlat), got {len(parts)}: {raw!r}"
+        )
+    minlon, minlat, maxlon, maxlat = parts
+    if not -180 <= minlon < maxlon <= 180:
+        raise ValueError(f"invalid longitude range: {minlon} >= {maxlon}")
+    if not -90 <= minlat < maxlat <= 90:
+        raise ValueError(f"invalid latitude range: {minlat} >= {maxlat}")
+    return minlon, minlat, maxlon, maxlat
+
+
+def _tile_path(tiles_dir: Path, tile: mercantile.Tile) -> Path:
+    """Return the cache path for a tile."""
+    return tiles_dir / str(tile.z) / str(tile.x) / f"{tile.y}.pbf"
+
+
+def _is_missing_tile(response: requests.Response) -> bool:
+    """Return True for Mapbox ``404 Tile not found`` (sparse / outside coverage).
+
+    A 404 whose body says the tileset itself does not exist is treated as a real
+    error so a bad tileset id fails the run instead of caching empty markers.
+    """
+    if response.status_code != 404:
+        return False
+    detail = (response.text or "").lower()
+    return "does not exist" not in detail
+
+
+def _download_tiles(
+    tileset: str,
+    access_token: str,
+    tiles_dir: Path,
+    to_fetch: list[mercantile.Tile],
+) -> tuple[int, int]:
+    """Fetch uncached tiles into ``tiles_dir``.
+
+    Parameters
+    ----------
+    tileset : str
+        Mapbox tileset id.
+    access_token : str
+        Mapbox access token.
+    tiles_dir : Path
+        Root of the local tile cache.
+    to_fetch : list of mercantile.Tile
+        Tiles that are not yet cached.
+
+    Returns
+    -------
+    tuple of int
+        ``(downloaded_count, failed_count)``.
+    """
+    if not to_fetch:
+        logger.info("Nothing to download: every tile is already cached locally.")
+        return 0, 0
+
+    downloaded = 0
+    failed = 0
+
+    with requests.Session() as session:
+        for i, tile in enumerate(to_fetch, 1):
+            url = (
+                f"https://api.mapbox.com/v4/{tileset}/"
+                f"{tile.z}/{tile.x}/{tile.y}.vector.pbf"
+            )
+            path = _tile_path(tiles_dir, tile)
+            try:
+                response = session.get(
+                    url,
+                    params={"access_token": access_token},
+                    timeout=_REQUEST_TIMEOUT_S,
+                )
+                if response.status_code == 200:
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_bytes(response.content)
+                    downloaded += 1
+                    logger.info(
+                        "[%s/%s] Tile %s/%s: downloaded (%s bytes)",
+                        i,
+                        len(to_fetch),
+                        tile.x,
+                        tile.y,
+                        len(response.content),
+                    )
+                elif response.status_code == 204 or _is_missing_tile(response):
+                    # 204: tile exists but is empty. 404 "Tile not found": sparse
+                    # coverage / outside the tileset extent. Cache an empty marker
+                    # so the cell is never re-requested.
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_bytes(b"")
+                    downloaded += 1
+                    logger.info(
+                        "[%s/%s] Tile %s/%s: empty (HTTP %s, cached marker)",
+                        i,
+                        len(to_fetch),
+                        tile.x,
+                        tile.y,
+                        response.status_code,
+                    )
+                else:
+                    failed += 1
+                    detail = (response.text or "").strip()
+                    logger.error(
+                        "[%s/%s] Tile %s/%s: failed with status %s%s",
+                        i,
+                        len(to_fetch),
+                        tile.x,
+                        tile.y,
+                        response.status_code,
+                        f": {detail}" if detail else "",
+                    )
+            except requests.RequestException as e:
+                failed += 1
+                logger.error(
+                    "[%s/%s] Tile %s/%s: failed: %s",
+                    i,
+                    len(to_fetch),
+                    tile.x,
+                    tile.y,
+                    e,
+                )
+
+    logger.info(
+        "Download pass complete: %s downloaded, %s failed.",
+        downloaded,
+        failed,
+    )
+    return downloaded, failed
+
+
+def _process_tiles(
+    tiles_dir: Path,
+    zoom: int,
+    reconstruct_column: str | None,
+) -> list[dict]:
+    """Convert cached PBF tiles at ``zoom`` into GeoJSON features.
+
+    Parameters
+    ----------
+    tiles_dir : Path
+        Root of the local tile cache.
+    zoom : int
+        Zoom level directory to read.
+    reconstruct_column : str or None
+        Optional property used to reconstruct features clipped across tiles.
+
+    Returns
+    -------
+    list of dict
+        GeoJSON Feature dictionaries.
+
+    Raises
+    ------
+    FileNotFoundError
+        If no cached tiles exist for the requested zoom.
+    """
+    zoom_dir = tiles_dir / str(zoom)
+    if not zoom_dir.is_dir():
+        raise FileNotFoundError(
+            f"No cached tiles found at {zoom_dir}. Download must run first."
+        )
+
+    all_features: list[dict] = []
+    tiles_read = 0
+    for x_dir in sorted(p for p in zoom_dir.iterdir() if p.is_dir()):
+        for path in sorted(x_dir.glob("*.pbf")):
+            if path.stat().st_size == 0:
+                continue
+            try:
+                x = int(x_dir.name)
+                y = int(path.stem)
+            except ValueError:
+                logger.warning("Skipping unexpected cache file %s", path)
+                continue
+            collection = vt_bytes_to_geojson(path.read_bytes(), x, y, zoom)
+            all_features.extend(collection.get("features", []))
+            tiles_read += 1
+
+    logger.info(
+        "Read %s cached tiles -> %s feature fragments.",
+        tiles_read,
+        len(all_features),
+    )
+
+    if reconstruct_column:
+        reconstructed = _reconstruct_features(all_features, reconstruct_column)
+        logger.info(
+            "Reconstructed on column %r: %s fragments -> %s features.",
+            reconstruct_column,
+            len(all_features),
+            len(reconstructed),
+        )
+        return reconstructed
+
+    return all_features
+
+
+def _reconstruct_features(features: list[dict], column: str) -> list[dict]:
+    """Reconstruct features clipped across tile boundaries.
+
+    Vector tiles clip geometries at tile edges, so one real-world feature can
+    appear as a fragment in several tiles. Grouping by ``column`` and unioning
+    geometries reconstructs the original feature. Features without the column
+    are passed through unchanged.
+
+    Parameters
+    ----------
+    features : list of dict
+        GeoJSON Feature dictionaries.
+    column : str
+        Property name used to group fragments.
+
+    Returns
+    -------
+    list of dict
+        Reconstructed GeoJSON Feature dictionaries.
+    """
+    from shapely.geometry import mapping, shape
+    from shapely.ops import linemerge, unary_union
+
+    groups: dict = {}
+    passthrough: list[dict] = []
+    for feature in features:
+        key = (feature.get("properties") or {}).get(column)
+        if key is None:
+            passthrough.append(feature)
+        else:
+            groups.setdefault(key, []).append(feature)
+
+    reconstructed: list[dict] = []
+    for group in groups.values():
+        if len(group) == 1:
+            reconstructed.append(group[0])
+            continue
+        merged = unary_union([shape(f["geometry"]) for f in group])
+        if merged.geom_type == "MultiLineString":
+            # union splits lines at shared nodes; merge fragments that connect
+            # end-to-end back into single LineStrings
+            merged = linemerge(merged)
+        reconstructed.append(
+            {
+                "type": "Feature",
+                "geometry": mapping(merged),
+                "properties": dict(group[0].get("properties") or {}),
+            }
+        )
+    return passthrough + reconstructed

--- a/f/connectors/mapbox/mapbox_download_vector_tiles.script.lock
+++ b/f/connectors/mapbox/mapbox_download_vector_tiles.script.lock
@@ -1,0 +1,15 @@
+# workspace-dependencies-mode: manual
+# py: 3.11
+certifi==2026.2.25
+charset-normalizer==3.4.5
+click==8.4.2
+idna==3.11
+mapbox-vector-tile==2.2.0
+mercantile==1.2.1
+numpy==2.4.6
+protobuf==6.33.6
+pyclipper==1.4.0
+requests==2.32.5
+shapely==2.1.2
+urllib3==2.6.3
+vt2geojson==0.2.1

--- a/f/connectors/mapbox/mapbox_download_vector_tiles.script.yaml
+++ b/f/connectors/mapbox/mapbox_download_vector_tiles.script.yaml
@@ -1,0 +1,96 @@
+summary: "Mapbox: Download Vector Tiles"
+description: >-
+  Download Mapbox vector tiles for a bounding box into a local cache, then
+  convert them into a single GeoJSON FeatureCollection. Tiles already present in
+  the cache are skipped. Use dry_run to inspect the tile count before spending
+  Mapbox API quota. Optionally reconstruct features that were clipped across
+  tile boundaries.
+lock: "!inline f/connectors/mapbox/mapbox_download_vector_tiles.script.lock"
+concurrency_time_window_s: 0
+kind: script
+schema:
+  $schema: "https://json-schema.org/draft/2020-12/schema"
+  type: object
+  order:
+    - mapbox
+    - bbox
+    - tileset
+    - zoom
+    - reconstruct_column
+    - output_filename
+    - attachment_root
+    - delete_tiles
+    - dry_run
+  properties:
+    attachment_root:
+      type: string
+      description: >-
+        Base directory for the tile cache and GeoJSON output. The tile cache is
+        stored under `{attachment_root}/{output_filename}/tiles/`, and the
+        GeoJSON is written to `{attachment_root}/{output_filename}.geojson`.
+      default: /persistent-storage/datalake/mapbox
+      originalType: string
+    bbox:
+      type: string
+      description: >-
+        Bounding box in WGS84 degrees as `minlon,minlat,maxlon,maxlat`, e.g.
+        `-77.8,-1.8,-76.0,-0.8`.
+      default: null
+      originalType: string
+    delete_tiles:
+      type: boolean
+      description: >-
+        If true, delete the tile cache after a successful GeoJSON write so only
+        the GeoJSON file remains on the datalake. Set to false to keep tiles for
+        faster re-runs (cached tiles are skipped on download).
+      default: true
+      originalType: boolean
+    dry_run:
+      type: boolean
+      description: >-
+        If true, return the tile download plan (counts and grid size) without
+        making any network requests or writing GeoJSON. Use this to check quota
+        cost before running a real download.
+      default: false
+      originalType: boolean
+    mapbox:
+      type: object
+      description: >-
+        A Mapbox credentials resource. Only the access token is used; a public
+        (`pk.`) or secret (`sk.`) token with Vector Tiles access works.
+      default: null
+      format: resource-mapbox
+    output_filename:
+      type: string
+      description: >-
+        Base name (without extension) for the output GeoJSON file and the tile
+        cache directory under `attachment_root`.
+      default: my_filename
+      originalType: string
+    reconstruct_column:
+      type: string
+      description: >-
+        Optional feature property used to reconstruct features that were
+        clipped across tile boundaries (by merging fragments that share this
+        property). Leave empty to disable reconstruction.
+      default: ""
+      originalType: string
+    tileset:
+      type: string
+      description: >-
+        Mapbox tileset id to download (e.g. `mapbox.mapbox-streets-v8`).
+      default: null
+      originalType: string
+    zoom:
+      type: string
+      description: >-
+        Zoom level of the tile grid to download (0-14). Higher zoom means more
+        detail and exponentially more tiles (~4x per level). Use dry_run to
+        check the tile count before downloading.
+      default: "12"
+      originalType: string
+      pattern: "^([0-9]|1[0-4])$"
+  required:
+    - mapbox
+    - bbox
+    - tileset

--- a/f/connectors/mapbox/tests/assets/server_responses.py
+++ b/f/connectors/mapbox/tests/assets/server_responses.py
@@ -120,3 +120,17 @@ def mapbox_create_tileset_response(
             "Publish your tileset to begin processing your data into tiles."
         ),
     }
+
+
+def mapbox_vector_tile_url(
+    tileset: str,
+    z: int,
+    x: int,
+    y: int,
+    access_token: str,
+) -> str:
+    """Build a Mapbox Vector Tiles API URL for a single tile."""
+    return (
+        f"{BASE_URL}/v4/{tileset}/{z}/{x}/{y}.vector.pbf"
+        f"?access_token={access_token}"
+    )

--- a/f/connectors/mapbox/tests/mapbox_download_vector_tiles_test.py
+++ b/f/connectors/mapbox/tests/mapbox_download_vector_tiles_test.py
@@ -1,0 +1,320 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import mercantile
+import pytest
+
+from f.connectors.mapbox.mapbox_download_vector_tiles import (
+    _reconstruct_features,
+    main,
+    mapbox,
+)
+from f.connectors.mapbox.tests.assets import server_responses
+
+ACCESS_TOKEN = "pk.ey_test_public_token"
+TILESET = "mapbox.mapbox-streets-v8"
+# Tiny bbox near the equator that resolves to a single tile at zoom 10.
+BBOX = "-77.05,-1.05,-77.04,-1.04"
+ZOOM = "10"
+
+
+def _tiles():
+    return list(
+        mercantile.tiles(*[float(p) for p in BBOX.split(",")], zooms=[int(ZOOM)])
+    )
+
+
+def _creds() -> mapbox:
+    return mapbox(username="unused", access_token=ACCESS_TOKEN)
+
+
+def _register_tile(
+    mocked_responses,
+    tile: mercantile.Tile,
+    *,
+    status: int = 200,
+    body: bytes = b"fake-pbf",
+):
+    url = server_responses.mapbox_vector_tile_url(
+        TILESET, tile.z, tile.x, tile.y, ACCESS_TOKEN
+    )
+    mocked_responses.get(
+        url,
+        body=body,
+        status=status,
+        content_type="application/vnd.mapbox-vector-tile",
+    )
+
+
+def test_dry_run_returns_plan_without_http(tmp_path, mocked_responses):
+    result = main(
+        mapbox=_creds(),
+        bbox=BBOX,
+        tileset=TILESET,
+        zoom=ZOOM,
+        attachment_root=str(tmp_path),
+        dry_run=True,
+    )
+
+    assert result["dry_run"] is True
+    assert result["tile_count"] == len(_tiles())
+    assert result["to_fetch_count"] == result["tile_count"]
+    assert result["cached_count"] == 0
+    assert result["tileset"] == TILESET
+    assert len(mocked_responses.calls) == 0
+
+
+def test_invalid_bbox_raises(tmp_path):
+    with pytest.raises(ValueError, match="expected four comma-separated"):
+        main(
+            mapbox=_creds(),
+            bbox="not-a-bbox",
+            tileset=TILESET,
+            attachment_root=str(tmp_path),
+            dry_run=True,
+        )
+
+
+def test_empty_tileset_raises(tmp_path):
+    with pytest.raises(ValueError, match="tileset is required"):
+        main(
+            mapbox=_creds(),
+            bbox=BBOX,
+            tileset="  ",
+            attachment_root=str(tmp_path),
+        )
+
+
+def test_zoom_out_of_range_raises(tmp_path):
+    with pytest.raises(ValueError, match="between 0 and 14"):
+        main(
+            mapbox=_creds(),
+            bbox=BBOX,
+            tileset=TILESET,
+            zoom="15",
+            attachment_root=str(tmp_path),
+            dry_run=True,
+        )
+
+
+def test_download_and_process_writes_geojson(tmp_path, mocked_responses):
+    tiles = _tiles()
+    assert len(tiles) == 1
+    tile = tiles[0]
+    _register_tile(mocked_responses, tile)
+
+    fake_features = [
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [-77.045, -1.045]},
+            "properties": {"name": "test"},
+        }
+    ]
+
+    with patch(
+        "f.connectors.mapbox.mapbox_download_vector_tiles.vt_bytes_to_geojson",
+        return_value={"type": "FeatureCollection", "features": fake_features},
+    ):
+        result = main(
+            mapbox=_creds(),
+            bbox=BBOX,
+            tileset=TILESET,
+            zoom=ZOOM,
+            output_filename="ecuador_tiles",
+            attachment_root=str(tmp_path),
+            delete_tiles=False,
+        )
+
+    assert result["dry_run"] is False
+    assert result["tiles_downloaded"] == 1
+    assert result["tiles_failed"] == 0
+    assert result["feature_count"] == 1
+    assert result["tiles_deleted"] is False
+    assert result["output_path"].endswith("ecuador_tiles.geojson")
+
+    cache_path = tmp_path / "ecuador_tiles" / "tiles" / str(tile.z) / str(tile.x) / f"{tile.y}.pbf"
+    assert cache_path.is_file()
+    assert cache_path.read_bytes() == b"fake-pbf"
+
+    geojson_path = Path(result["output_path"])
+    assert geojson_path.is_file()
+    saved = json.loads(geojson_path.read_text())
+    assert saved["features"][0]["properties"]["name"] == "test"
+    assert len(mocked_responses.calls) == 1
+
+
+def test_delete_tiles_removes_cache_after_success(tmp_path, mocked_responses):
+    tile = _tiles()[0]
+    _register_tile(mocked_responses, tile)
+
+    with patch(
+        "f.connectors.mapbox.mapbox_download_vector_tiles.vt_bytes_to_geojson",
+        return_value={
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [0, 0]},
+                    "properties": {},
+                }
+            ],
+        },
+    ):
+        result = main(
+            mapbox=_creds(),
+            bbox=BBOX,
+            tileset=TILESET,
+            zoom=ZOOM,
+            output_filename="cleanup",
+            attachment_root=str(tmp_path),
+            delete_tiles=True,
+        )
+
+    assert result["tiles_deleted"] is True
+    assert Path(result["output_path"]).is_file()
+    assert not (tmp_path / "cleanup" / "tiles").exists()
+    assert not (tmp_path / "cleanup").exists()
+
+
+def test_blank_tile_cached_as_empty_marker(tmp_path, mocked_responses):
+    tile = _tiles()[0]
+    _register_tile(mocked_responses, tile, status=204, body=b"")
+
+    result = main(
+        mapbox=_creds(),
+        bbox=BBOX,
+        tileset=TILESET,
+        zoom=ZOOM,
+        output_filename="blank",
+        attachment_root=str(tmp_path),
+        delete_tiles=False,
+    )
+
+    assert result["tiles_downloaded"] == 1
+    assert result["feature_count"] == 0
+    cache_path = tmp_path / "blank" / "tiles" / str(tile.z) / str(tile.x) / f"{tile.y}.pbf"
+    assert cache_path.is_file()
+    assert cache_path.stat().st_size == 0
+
+
+def test_missing_tile_404_cached_as_empty_marker(tmp_path, mocked_responses):
+    tile = _tiles()[0]
+    _register_tile(mocked_responses, tile, status=404, body=b"Tile not found")
+
+    result = main(
+        mapbox=_creds(),
+        bbox=BBOX,
+        tileset=TILESET,
+        zoom=ZOOM,
+        output_filename="missing",
+        attachment_root=str(tmp_path),
+        delete_tiles=False,
+    )
+
+    assert result["tiles_downloaded"] == 1
+    assert result["tiles_failed"] == 0
+    assert result["feature_count"] == 0
+    cache_path = (
+        tmp_path / "missing" / "tiles" / str(tile.z) / str(tile.x) / f"{tile.y}.pbf"
+    )
+    assert cache_path.is_file()
+    assert cache_path.stat().st_size == 0
+
+
+def test_cache_skip_does_not_re_request(tmp_path, mocked_responses):
+    tile = _tiles()[0]
+    cache_path = (
+        tmp_path / "cached" / "tiles" / str(tile.z) / str(tile.x) / f"{tile.y}.pbf"
+    )
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_bytes(b"already-cached")
+
+    with patch(
+        "f.connectors.mapbox.mapbox_download_vector_tiles.vt_bytes_to_geojson",
+        return_value={
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [0, 0]},
+                    "properties": {},
+                }
+            ],
+        },
+    ):
+        result = main(
+            mapbox=_creds(),
+            bbox=BBOX,
+            tileset=TILESET,
+            zoom=ZOOM,
+            output_filename="cached",
+            attachment_root=str(tmp_path),
+            delete_tiles=False,
+        )
+
+    assert result["tiles_downloaded"] == 0
+    assert result["tiles_cached_skipped"] == 1
+    assert result["to_fetch_count"] == 0
+    assert result["tiles_deleted"] is False
+    assert len(mocked_responses.calls) == 0
+    assert cache_path.is_file()
+
+
+def test_tile_failure_raises(tmp_path, mocked_responses):
+    tile = _tiles()[0]
+    _register_tile(mocked_responses, tile, status=500, body=b"error")
+
+    with pytest.raises(RuntimeError, match="Failed to download 1"):
+        main(
+            mapbox=_creds(),
+            bbox=BBOX,
+            tileset=TILESET,
+            zoom=ZOOM,
+            output_filename="fail",
+            attachment_root=str(tmp_path),
+        )
+
+    cache_path = tmp_path / "fail" / "tiles" / str(tile.z) / str(tile.x) / f"{tile.y}.pbf"
+    assert not cache_path.exists()
+
+
+def test_reconstruct_features_merges_by_column():
+    features = [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [[0, 0], [1, 0]],
+            },
+            "properties": {"id": "road-1", "name": "Main"},
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [[1, 0], [2, 0]],
+            },
+            "properties": {"id": "road-1", "name": "Main"},
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [5, 5],
+            },
+            "properties": {"name": "no-id"},
+        },
+    ]
+
+    reconstructed = _reconstruct_features(features, "id")
+    assert len(reconstructed) == 2
+    by_id = [
+        f for f in reconstructed if (f.get("properties") or {}).get("id") == "road-1"
+    ]
+    assert len(by_id) == 1
+    assert by_id[0]["geometry"]["type"] in {"LineString", "MultiLineString"}
+    passthrough = [
+        f for f in reconstructed if "id" not in (f.get("properties") or {})
+    ]
+    assert len(passthrough) == 1

--- a/f/connectors/mapbox/tests/mapbox_download_vector_tiles_test.py
+++ b/f/connectors/mapbox/tests/mapbox_download_vector_tiles_test.py
@@ -86,18 +86,6 @@ def test_empty_tileset_raises(tmp_path):
         )
 
 
-def test_zoom_out_of_range_raises(tmp_path):
-    with pytest.raises(ValueError, match="between 0 and 14"):
-        main(
-            mapbox=_creds(),
-            bbox=BBOX,
-            tileset=TILESET,
-            zoom="15",
-            attachment_root=str(tmp_path),
-            dry_run=True,
-        )
-
-
 def test_download_and_process_writes_geojson(tmp_path, mocked_responses):
     tiles = _tiles()
     assert len(tiles) == 1
@@ -133,7 +121,14 @@ def test_download_and_process_writes_geojson(tmp_path, mocked_responses):
     assert result["tiles_deleted"] is False
     assert result["output_path"].endswith("ecuador_tiles.geojson")
 
-    cache_path = tmp_path / "ecuador_tiles" / "tiles" / str(tile.z) / str(tile.x) / f"{tile.y}.pbf"
+    cache_path = (
+        tmp_path
+        / "ecuador_tiles"
+        / "tiles"
+        / str(tile.z)
+        / str(tile.x)
+        / f"{tile.y}.pbf"
+    )
     assert cache_path.is_file()
     assert cache_path.read_bytes() == b"fake-pbf"
 
@@ -193,7 +188,9 @@ def test_blank_tile_cached_as_empty_marker(tmp_path, mocked_responses):
 
     assert result["tiles_downloaded"] == 1
     assert result["feature_count"] == 0
-    cache_path = tmp_path / "blank" / "tiles" / str(tile.z) / str(tile.x) / f"{tile.y}.pbf"
+    cache_path = (
+        tmp_path / "blank" / "tiles" / str(tile.z) / str(tile.x) / f"{tile.y}.pbf"
+    )
     assert cache_path.is_file()
     assert cache_path.stat().st_size == 0
 
@@ -275,7 +272,9 @@ def test_tile_failure_raises(tmp_path, mocked_responses):
             attachment_root=str(tmp_path),
         )
 
-    cache_path = tmp_path / "fail" / "tiles" / str(tile.z) / str(tile.x) / f"{tile.y}.pbf"
+    cache_path = (
+        tmp_path / "fail" / "tiles" / str(tile.z) / str(tile.x) / f"{tile.y}.pbf"
+    )
     assert not cache_path.exists()
 
 
@@ -314,7 +313,5 @@ def test_reconstruct_features_merges_by_column():
     ]
     assert len(by_id) == 1
     assert by_id[0]["geometry"]["type"] in {"LineString", "MultiLineString"}
-    passthrough = [
-        f for f in reconstructed if "id" not in (f.get("properties") or {})
-    ]
+    passthrough = [f for f in reconstructed if "id" not in (f.get("properties") or {})]
     assert len(passthrough) == 1

--- a/tox.ini
+++ b/tox.ini
@@ -141,6 +141,7 @@ commands =
 [testenv:mapbox]
 deps =
     -r{toxinidir}/f/connectors/mapbox/mapbox_create_or_update_tileset.script.lock
+    -r{toxinidir}/f/connectors/mapbox/mapbox_download_vector_tiles.script.lock
     -r{toxinidir}/f/common_logic/geo_utils.script.lock
     -r{toxinidir}/f/connectors/mapbox/tests/requirements-test.txt
 allowlist_externals =


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-scripts-hub/issues/272.

## Screenshots

<img width="1042" height="868" alt="image" src="https://github.com/user-attachments/assets/ec9e6d25-fcde-4f48-b742-1dae4fcfcc4a" />

## What I changed and why

- Basically, I took @nicopace's clever and fully functional [`download_mapbox_data.py`](https://github.com/ConservationMetrics/gc-programs/blob/main/scripts/mapbox/download_mapbox_data.py) script in `gc-programs` and turned it into a production-grade script for `gc-scripts-hub` with Windmill parameterization and tests.
- Some changes I made to the script:
  - Used `mercantile` to convert lat/lon to tile coordinates instead of custom `deg2num` fn
  - In addition to `204` status code, I also discovered that the Mapbox API can return `404` for when there is no coverage outside the tileset extent. So for this we cache an empty marker so the cell is never re-requested.
  - Got rid of `max_zoom` arg, handle validation in `zoom` instead.
  - Instead of `tileset` being an Array, I think it's better to run this script tile-by-tile. As the `reconstruct_column` might differ from source to source. So I think the mental model is better for this to be 1 run per tileset.
  - Implemented other repo-wide standards like use of `logging`, `pathlib`, and our `save_data-to_file` library to handle saving as GeoJSON.
- Lastly, I discovered that `minimum` and `maximum` conditions don't work for Integer parameters (i.e. what was being used for zoom level). So instead I set those fields -- for both mapbox scripts -- to String, and used a `validation` instead to validate a proper zoom level and ceiling.


## How I convinced myself this is right

- Trying it in Windmill runtime.
- See https://github.com/ConservationMetrics/gc-programs/issues/190 for partner-based motivation on the original script, and why we've added it here.

## What I'm not doing here

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

I used Cursor Grok 4.5 to Windmill-ize the existing script and apply `gc-scripts-hub` coding patterns, and generate tests. Then I made various changes to improve the code, like implementing `mercantile` and streamlining the script params.