### PR TITLE
[Dataset uploader] show pending state message for dataset name check

### DIFF
--- a/f/apps/gc_dataset_importer.app/1_eval_of_enterdatasetnameresult.inline_script.frontend.js
+++ b/f/apps/gc_dataset_importer.app/1_eval_of_enterdatasetnameresult.inline_script.frontend.js
@@ -4,6 +4,11 @@ if (!newName) {
   return "";
 }
 
+// Pending: this typed name hasn't finished resolving yet
+if (typeof state.tableExists !== "boolean" && newName) {
+  return "Checking if dataset exists...";
+}
+
 // Only show a result once the async check has resolved for THIS typed name.
 // Otherwise the message would flash the previously resolved (e.g. dropdown) value.
 if (state.datasetName !== newName) {

--- a/f/apps/gc_dataset_importer.app/app.yaml
+++ b/f/apps/gc_dataset_importer.app/app.yaml
@@ -691,7 +691,7 @@ value:
               value: true
             style:
               type: static
-              value: Label
+              value: Caption
             tooltip:
               type: static
               value: ''


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-scripts-hub/issues/266

## Screenshots

<img width="1042" height="770" alt="image" src="https://github.com/user-attachments/assets/f60705a0-676b-432c-98f5-bd77c158313d" />

## What I changed and why

- Added a case where `state.tableExists` is not true/false, but `newName` is already set
- Set text field style to Caption instead of Label as it's what we tend to use for these text info fields

## How I convinced myself this is right

Testing in runtime

## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->
