### PR TITLE
Fix Dataset Importer Excel values, save gating, and column-name sanitization

### DIFF
--- a/f/apps/gc_dataset_importer.app/2_upload_and_convert_file.inline_script.py
+++ b/f/apps/gc_dataset_importer.app/2_upload_and_convert_file.inline_script.py
@@ -145,7 +145,11 @@ def main(uploaded_file, dataset_name, table_exists, table_name, db: postgresql):
                     f"Analyzing changes for {len(data_for_comparison)} rows against existing table"
                 )
                 new_rows, updates, new_columns = summarize_new_rows_updates_and_columns(
-                    db, table_name=table_name, new_data=data_for_comparison
+                    db,
+                    table_name=table_name,
+                    new_data=data_for_comparison,
+                    reverse_properties_separated_by="/",
+                    sep_policy="underscore",
                 )
                 logger.info(
                     f"Impact analysis complete: {new_rows} new rows, {updates} updates, {new_columns} new columns"

--- a/f/apps/gc_dataset_importer.app/4_apply_transformation_and_write_to_database.inline_script.py
+++ b/f/apps/gc_dataset_importer.app/4_apply_transformation_and_write_to_database.inline_script.py
@@ -144,6 +144,8 @@ def main(
                 db_table_name=valid_sql_name,
                 geojson_path=file_path_obj.name,
                 attachment_root=str(file_path_obj.parent),
+                reverse_properties_separated_by="/",
+                sep_policy="underscore",
             )
             logger.info(f"GeoJSON saved to PostgreSQL table: {valid_sql_name}")
         else:  # csv
@@ -152,6 +154,8 @@ def main(
                 db_table_name=valid_sql_name,
                 csv_path=file_path_obj.name,
                 attachment_root=str(file_path_obj.parent),
+                reverse_properties_separated_by="/",
+                sep_policy="underscore",
             )
             logger.info(f"CSV saved to PostgreSQL table: {valid_sql_name}")
 

--- a/f/apps/gc_dataset_importer.app/4_eval_of_saveresult.inline_script.frontend.js
+++ b/f/apps/gc_dataset_importer.app/4_eval_of_saveresult.inline_script.frontend.js
@@ -1,4 +1,4 @@
-if (state.newRows === 0 && state.updatedRows === 0) {
+if (state.newRows === 0 && state.updatedRows === 0 && !state.newColumns) {
   return "No rows to update!"
 } else if (state.finalizeSuccess) {
   return "✅ Dataset successfully written to the data warehouse! Navigate to a Guardian Connector tool like GC Explorer to set up a view for your dataset."

--- a/f/apps/gc_dataset_importer.app/app.yaml
+++ b/f/apps/gc_dataset_importer.app/app.yaml
@@ -2364,11 +2364,13 @@ value:
                   componentId: state
                 - id: newRows
                   componentId: state
+                - id: updatedRows
+                  componentId: state
                 - id: finalizeSuccess
                   componentId: state
               expr: >-
-                state.finalizeSuccess || !(state.newRows > 0 && state.newColumns
-                > 0)
+                state.finalizeSuccess || !(state.newRows > 0 ||
+                state.updatedRows > 0 || state.newColumns > 0)
             fillContainer:
               type: static
               value: false
@@ -2455,6 +2457,8 @@ value:
                     key: newRows
                   - id: state
                     key: updatedRows
+                  - id: state
+                    key: newColumns
                 suggestedRefreshOn: []
           configuration:
             copyButton:

--- a/f/common_logic/data_conversion.py
+++ b/f/common_logic/data_conversion.py
@@ -11,6 +11,7 @@ import json
 import logging
 import re
 import xml.etree.ElementTree as ET
+from numbers import Integral, Real
 from pathlib import Path
 
 import filetype
@@ -487,6 +488,33 @@ def read_csv(path: Path):
         return rows
 
 
+def _stringify_tabular_value(value) -> str:
+    """Convert a pandas/Excel cell to a string without inventing a trailing ``.0``.
+
+    Excel stores numbers as IEEE floats, so pandas reads whole values such as
+    ``42`` as ``42.0``. ``DataFrame.astype(str)`` would then emit ``"42.0"``.
+    Whole numeric values are rendered as integers; genuine fractional values
+    keep their decimal. Missing cells become ``""`` rather than ``"nan"``.
+    Text cells that already contain ``"5.0"`` are left unchanged.
+    """
+    if isinstance(value, str):
+        return value.strip()
+    if value is None or (
+        not isinstance(value, (bytes, dict, list)) and pd.isna(value)
+    ):
+        return ""
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, Integral):
+        return str(int(value))
+    if isinstance(value, Real):
+        number = float(value)
+        if number.is_integer():
+            return str(int(number))
+        return str(number)
+    return str(value).strip()
+
+
 @handle_file_errors
 def read_excel(path: Path):
     """
@@ -505,10 +533,10 @@ def read_excel(path: Path):
             "Excel file contains multiple sheets; only single-sheet files are supported at the moment."
         )
     df = excel.parse(sheet_name=0)
-
-    # Strip whitespace from all cells in the DataFrame
-    df = df.astype(str).apply(lambda col: col.str.strip())
-    rows = [df.columns.tolist()] + df.values.tolist()
+    rows = [[_stringify_tabular_value(c) for c in df.columns]] + [
+        [_stringify_tabular_value(v) for v in row]
+        for row in df.itertuples(index=False, name=None)
+    ]
 
     if len(rows) <= 1:
         raise ValueError("Excel file contains no data")

--- a/f/common_logic/db_operations.py
+++ b/f/common_logic/db_operations.py
@@ -231,6 +231,7 @@ def summarize_new_rows_updates_and_columns(
     primary_key: str = "_id",
     str_replace: list[tuple[str, str]] = None,
     reverse_properties_separated_by: str = None,
+    sep_policy: str = "remove",
 ):
     """
     Compare uploaded dataset against existing table to determine impact.
@@ -258,6 +259,9 @@ def summarize_new_rows_updates_and_columns(
     reverse_properties_separated_by : str or None, optional
         If provided, splits keys on this character, reverses segments, and rejoins.
         Must match the StructuredDBWriter settings. Defaults to None.
+    sep_policy : str, optional
+        Column-name separator policy for ``sanitize_sql_message``. Must match
+        StructuredDBWriter. Defaults to ``"remove"``.
 
     Returns
     -------
@@ -315,6 +319,7 @@ def summarize_new_rows_updates_and_columns(
                 reverse_properties_separated_by=reverse_properties_separated_by,
                 str_replace=str_replace,
                 maxlen=63,
+                sep_policy=sep_policy,
             )
 
             # Extract just the normalized column names (values from column_mapping)
@@ -437,6 +442,9 @@ class StructuredDBWriter:
        If provided, splits keys on this character, reverses segments, and rejoins — useful for nested property flattening.
      str_replace : list of tuple, optional
          List of (old, new) strings to apply to keys during sanitization.
+     sep_policy : str, optional
+         Separator policy for column sanitization (``"remove"`` or ``"underscore"``).
+         Defaults to ``"remove"`` to match existing warehouse columns.
      predefined_schema : callable or None, optional
          If provided, this function is executed to create or validate the schema before inserting any data.
          Signature: `(cursor, table_name) -> None`
@@ -456,6 +464,7 @@ class StructuredDBWriter:
         use_mapping_table=False,
         reverse_properties_separated_by=None,
         str_replace=[("/", "__"), ("$", "__")],
+        sep_policy="remove",
         predefined_schema=None,
     ):
         self.db_connection_string = db_connection_string
@@ -478,6 +487,7 @@ class StructuredDBWriter:
         self.use_mapping_table = use_mapping_table
         self.reverse_separator = reverse_properties_separated_by
         self.str_replace = str_replace
+        self.sep_policy = sep_policy
         self.predefined_schema = predefined_schema
 
     def _get_conn(self):
@@ -680,6 +690,7 @@ class StructuredDBWriter:
                     existing_mappings,
                     reverse_properties_separated_by=self.reverse_separator,
                     str_replace=self.str_replace,
+                    sep_policy=self.sep_policy,
                 )
                 rows.append((sanitized, existing_mappings))
                 original_to_sql.update(updated)

--- a/f/common_logic/identifier_utils.py
+++ b/f/common_logic/identifier_utils.py
@@ -169,6 +169,7 @@ def sanitize_sql_message(
     reverse_properties_separated_by=None,
     str_replace=[],
     maxlen=63,
+    sep_policy="remove",
 ):
     """Sanitize a message for SQL compatibility and rename columns.
 
@@ -190,6 +191,10 @@ def sanitize_sql_message(
         A list of tuples specifying string replacements, by default [].
     maxlen : int, optional
         Maximum length of the returned identifier. Longer strings are truncated. Default is 63 (PostgreSQL identifier limit).
+    sep_policy : str, optional
+        Passed to ``normalize_identifier``. Default is ``"remove"`` so existing
+        warehouse columns keep matching. Use ``"underscore"`` to turn spaces
+        (and ``-./``) into ``_`` instead of deleting them.
 
     Returns
     -------
@@ -223,8 +228,8 @@ def sanitize_sql_message(
             maxlen=maxlen,
             make_snake=False,
             ensure_leading_alpha=False,
-            sep_policy="remove",
-        )  # These values are set to guarantee backwards compatibility, as existing warehouse data was already processed with these settings
+            sep_policy=sep_policy,
+        )  # make_snake/ensure_leading_alpha stay off for warehouse backwards compatibility. Default sep_policy is "remove" for the same reason; Dataset Importer passes "underscore".
         key = _shorten_and_uniqify(key, updated_column_renames.values(), maxlen)
 
         updated_column_renames[original_key] = key

--- a/f/common_logic/tests/data_conversion_test.py
+++ b/f/common_logic/tests/data_conversion_test.py
@@ -1134,6 +1134,48 @@ def test_convert_data__kobotoolbox_xlsx(kobotoolbox_excel_file):
     assert "Arlington" in record
     assert "Flourishing" in record
     assert "bamboo, wild boar" in record
+    assert record[headers.index("_id")] == "254135872"
+    assert record[headers.index("_index")] == "1"
+
+
+def test_convert_data__xlsx_preserves_integer_and_explicit_decimals(tmp_path):
+    """Excel stores numbers as floats; whole values must not gain a trailing .0."""
+    from openpyxl import Workbook
+
+    path = tmp_path / "numbers.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["id", "count", "score", "note"])
+    ws.append([1, 42, 3.14, "ok"])
+    ws.append([2, 0, 1.5, "  padded  "])
+    ws["A4"] = "3"
+    ws["B4"] = 10.0
+    ws["C4"] = None
+    ws["D4"] = "5.0"
+    wb.save(path)
+
+    result, output_format = convert_data([str(path)], "xlsx")
+    assert output_format == "csv"
+    assert result == [
+        ["id", "count", "score", "note"],
+        ["1", "42", "3.14", "ok"],
+        ["2", "0", "1.5", "padded"],
+        ["3", "10", "", "5.0"],
+    ]
+
+
+def test_convert_data__csv_preserves_written_number_text(tmp_path):
+    """CSV values stay as written: 42 stays 42, 42.0 stays 42.0."""
+    path = tmp_path / "numbers.csv"
+    path.write_text("id,count,score\n1,42,3.14\n2,42.0,1.50\n")
+
+    result, output_format = convert_data([str(path)], "csv")
+    assert output_format == "csv"
+    assert result == [
+        ["id", "count", "score"],
+        ["1", "42", "3.14"],
+        ["2", "42.0", "1.50"],
+    ]
 
 
 def test_convert_data__kobotoolbox_multiple_sheets_xlsx(

--- a/f/common_logic/tests/identifier_utils_test.py
+++ b/f/common_logic/tests/identifier_utils_test.py
@@ -10,6 +10,22 @@ from f.common_logic.identifier_utils import (
 )
 
 
+def test_sanitize_sql_message__spaces_become_underscores():
+    """Dataset Importer keeps word spaces as _ and reverses group/question paths."""
+    message = {"Basic information/Are you married?": "yes"}
+    sql_message, mapping = sanitize_sql_message(
+        message,
+        {},
+        reverse_properties_separated_by="/",
+        str_replace=[("/", "__"), ("$", "__")],
+        sep_policy="underscore",
+    )
+    assert sql_message == {"Are_you_married__Basic_information": "yes"}
+    assert mapping == {
+        "Basic information/Are you married?": "Are_you_married__Basic_information"
+    }
+
+
 def test_sanitize_sql_message():
     message = {
         "col.1": 1,

--- a/f/connectors/csv/csv_to_postgres.py
+++ b/f/connectors/csv/csv_to_postgres.py
@@ -20,6 +20,7 @@ def main(
     id_column: str = None,
     use_mapping_table: bool = False,
     reverse_properties_separated_by: str | None = None,
+    sep_policy: str = "remove",
 ):
     """
     Import CSV data into PostgreSQL table.
@@ -42,6 +43,8 @@ def main(
         Forwarded to ``StructuredDBWriter``. See StructuredDBWriter documentation for more details.
     reverse_properties_separated_by : str, optional
         Forwarded to ``StructuredDBWriter``. See StructuredDBWriter documentation for more details.
+    sep_policy : str, optional
+        Forwarded to ``StructuredDBWriter``. See StructuredDBWriter documentation for more details.
     """
     csv_path = Path(attachment_root) / Path(csv_path)
     transformed_csv_data = transform_csv_data(csv_path, id_column)
@@ -51,6 +54,7 @@ def main(
         db_table_name,
         use_mapping_table=use_mapping_table,
         reverse_properties_separated_by=reverse_properties_separated_by,
+        sep_policy=sep_policy,
     )
     db_writer.handle_output(transformed_csv_data)
 

--- a/f/connectors/geojson/geojson_to_postgres.py
+++ b/f/connectors/geojson/geojson_to_postgres.py
@@ -18,6 +18,8 @@ def main(
     geojson_path: str,
     attachment_root: str = "/persistent-storage/datalake/",
     delete_geojson_file: bool = False,
+    reverse_properties_separated_by: str | None = None,
+    sep_policy: str = "remove",
 ):
     geojson_path = Path(attachment_root) / Path(geojson_path)
     transformed_geojson_data = transform_geojson_data(geojson_path)
@@ -26,7 +28,8 @@ def main(
         conninfo(db),
         db_table_name,
         use_mapping_table=False,
-        reverse_properties_separated_by=None,
+        reverse_properties_separated_by=reverse_properties_separated_by,
+        sep_policy=sep_policy,
     )
     db_writer.handle_output(transformed_geojson_data)
 


### PR DESCRIPTION
## Goal

Make Dataset Importer round-trip spreadsheet data more faithfully and actually allow updates to existing tables.

## What I changed and why

- Excel (and similar tabular) values that are whole numbers are no longer stringified with a trailing `.0`, and and empty cells become "" instead of "nan".
- Dataset Importer **Save & Finish** is enabled when there are new rows, updated rows, or new columns, so re-uploads of an existing dataset are no longer blocked.
- Dataset Importer column names now keep word spaces as underscores and reverse `/`-separated group/question paths the same way Kobo does (`Basic information/Are you married?` → `Are_you_married__Basic_information`).

## How I convinced myself this is right

Working with cleaned up Kobo data from a partner and noticing these discrepancies and issues.

## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Very informed prompting to Cursor Grok 4.5 to make these changes, and add tests.