### PR TITLE
Remove tox-docker and add gcp_storage_emulator directly to pytest runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,6 @@ workflows:
 jobs:
   test:
     resource_class: medium
-    # machine executor is required to expose ports in tox-docker:
-    # https://circleci.com/docs/2.0/building-docker-images/#mounting-folders
     executor: machine-executor
 
     steps:
@@ -44,14 +42,9 @@ jobs:
           name: Install tox for Python 3.11
           command: |
             python -m pip install --upgrade "pip>=26.1"
-            pip install tox~=4.18 tox-docker~=5.0
+            pip install tox~=4.18
       - run:
           name: Run tests
           command: tox -- -v
           environment:
             PIP_UPLOADED_PRIOR_TO: P7D
-            # Skip tox-docker's NetworkSettings.Gateway lookup (broken on newer
-            # Docker in ubuntu-2404:current). machine-executor reaches containers
-            # via localhost anyway. Workaround until https://github.com/tox-dev/tox-docker/pull/196
-            # is merged and released.
-            TOX_DOCKER_GATEWAY: localhost

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Make sure you have Python installed locally or create a virtual environment for 
 
 Install the following dependencies:
   ```bash
-  pip install 'tox>=4.15.0,<5' 'tox-docker~=5.0'
+  pip install 'tox>=4.15.0,<5'
   ```
 
 Then you can run all tests using tox:
@@ -165,11 +165,8 @@ If you are using homebrew you might have better luck using `pipx` or `uvx` to ma
 test runner:
   ```bash
   # Install test runner and run test in one go
-  uvx --with tox-docker tox
+  uvx tox
   ```
-
-The `tox-docker` test runner dependency is only required
-to run the `alerts` test suite; others can run with only `tox`.
 
 ### Individual Test Suites
 

--- a/f/connectors/alerts/tests/conftest.py
+++ b/f/connectors/alerts/tests/conftest.py
@@ -1,7 +1,6 @@
-import os
-
 import pytest
 import testing.postgresql
+from gcp_storage_emulator.server import create_server
 from google.auth.credentials import AnonymousCredentials
 from google.cloud import storage
 
@@ -18,23 +17,21 @@ def pg_database():
 
 @pytest.fixture
 def gcs_emulator_client():
-    """Return a google.cloud.storage.Client against an GCS emulator running in tox-docker"""
-    # See https://github.com/tox-dev/tox-docker?tab=readme-ov-file#configuration, `expose` option
+    """Return a google.cloud.storage.Client connected to a local GCS emulator."""
+    host = "127.0.0.1"
+    # Port 0 lets the OS select and bind a free port atomically, avoiding an allocation race.
+    emulator_server = create_server(host, 0, in_memory=True)
+    emulator_server.start()
     try:
-        TOX_DOCKER_GCS_PORT = os.environ["TOX_DOCKER_GCS_PORT"]
-    except KeyError:
-        raise RuntimeError("You need to: $ pip install tox-docker")
-    emulator_endpoint = f"http://localhost:{TOX_DOCKER_GCS_PORT}"
-
-    # Create a storage client that connects to the emulator
-    storage_client = storage.Client(
-        project="test-project",
-        credentials=AnonymousCredentials(),
-        client_options={"api_endpoint": emulator_endpoint},
-    )
-
-    yield storage_client
-
-    # Clean up: Delete all buckets
-    for bucket in storage_client.list_buckets():
-        bucket.delete(force=True)
+        port = emulator_server._api._httpd.server_address[1]
+        storage_client = storage.Client(
+            project="test-project",
+            credentials=AnonymousCredentials(),
+            client_options={"api_endpoint": f"http://{host}:{port}"},
+        )
+        try:
+            yield storage_client
+        finally:
+            storage_client.close()
+    finally:
+        emulator_server.stop()

--- a/f/connectors/alerts/tests/requirements-test.txt
+++ b/f/connectors/alerts/tests/requirements-test.txt
@@ -1,2 +1,3 @@
+gcp-storage-emulator==2026.7.19
 pytest
 testing.postgresql

--- a/tox.ini
+++ b/tox.ini
@@ -11,18 +11,8 @@ setenv =
 deps =
     -r{toxinidir}/f/connectors/alerts/alerts_gcs.script.lock
     -r{toxinidir}/f/connectors/alerts/tests/requirements-test.txt
-docker =
-    gcp-storage-emulator
 commands =
     pytest {posargs} f/connectors/alerts
-
-[docker:gcp-storage-emulator]
-image = oittaa/gcp-storage-emulator
-environment =
-    PORT=10010
-expose =
-    TOX_DOCKER_GCS_PORT=10010/tcp
-network_mode = bridge
 
 [testenv:arcgis]
 deps =


### PR DESCRIPTION
## Goal
Make repo more compatible with containerized workspaces (devcontainer.json).

More details in the issue - #277 

## Screenshots
No visual changes

## What I changed and why
Removed tox-docker from configs and readme.
Updated conftest.py to directly invoke `gcp_storage_emulator` in memory, rather than going over the docker network.

## How I convinced myself this is right
Same tests pass without refactor

## What I'm not doing here
No runtime changes, No change in test coverage nor major test refactor

## LLM use disclosure
GPT 5.6 Sol via OpenCode
