### PR TITLE
Test Speedup #2 - Run tox environments with two workers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
             pip install tox~=4.18 tox-docker~=5.0
       - run:
           name: Run tests
-          command: tox -- -v
+          command: tox -p 2 -- -v
           environment:
             PIP_UPLOADED_PRIOR_TO: P7D
             # Skip tox-docker's NetworkSettings.Gateway lookup (broken on newer

--- a/f/common_logic/tests/conftest.py
+++ b/f/common_logic/tests/conftest.py
@@ -11,7 +11,7 @@ from f.common_logic.db_operations import conninfo
 @pytest.fixture(scope="function")
 def _postgres_instance():
     """Spin up a temporary PostgreSQL instance for tests."""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     try:
         yield db
     finally:

--- a/f/connectors/alerts/tests/conftest.py
+++ b/f/connectors/alerts/tests/conftest.py
@@ -9,11 +9,11 @@ from google.cloud import storage
 @pytest.fixture
 def pg_database():
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn
-    db.stop
+    db.stop()
 
 
 @pytest.fixture

--- a/f/connectors/arcgis/tests/conftest.py
+++ b/f/connectors/arcgis/tests/conftest.py
@@ -154,8 +154,8 @@ def arcgis_anonymous_server(mocked_responses):
 @pytest.fixture
 def pg_database():
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn
-    db.stop
+    db.stop()

--- a/f/connectors/auditor2/tests/conftest.py
+++ b/f/connectors/auditor2/tests/conftest.py
@@ -5,7 +5,7 @@ import testing.postgresql
 @pytest.fixture
 def pg_database():
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/comapeo/tests/conftest.py
+++ b/f/connectors/comapeo/tests/conftest.py
@@ -243,8 +243,8 @@ def comapeoserver_with_failing_attachments(mocked_responses):
 
 @pytest.fixture
 def pg_database():
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn
-    db.stop
+    db.stop()

--- a/f/connectors/csv/tests/conftest.py
+++ b/f/connectors/csv/tests/conftest.py
@@ -5,7 +5,7 @@ import testing.postgresql
 @pytest.fixture
 def pg_database():
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/cybertracker/tests/conftest.py
+++ b/f/connectors/cybertracker/tests/conftest.py
@@ -6,7 +6,7 @@ from pathlib import Path
 @pytest.fixture
 def pg_database():
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/earthindex/tests/conftest.py
+++ b/f/connectors/earthindex/tests/conftest.py
@@ -51,7 +51,7 @@ def earthindex_server_no_layers(mocked_responses):
 
 @pytest.fixture
 def pg_database():
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/epicollect/tests/conftest.py
+++ b/f/connectors/epicollect/tests/conftest.py
@@ -178,8 +178,8 @@ def epicollect_public_server(mocked_responses):
 
 @pytest.fixture
 def pg_database():
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn
-    db.stop
+    db.stop()

--- a/f/connectors/geojson/tests/conftest.py
+++ b/f/connectors/geojson/tests/conftest.py
@@ -5,7 +5,7 @@ import testing.postgresql
 @pytest.fixture
 def pg_database():
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/globalforestwatch/tests/conftest.py
+++ b/f/connectors/globalforestwatch/tests/conftest.py
@@ -40,8 +40,8 @@ def gfw_server(mocked_responses):
 @pytest.fixture
 def pg_database():
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn
-    db.stop
+    db.stop()

--- a/f/connectors/inaturalist/tests/conftest.py
+++ b/f/connectors/inaturalist/tests/conftest.py
@@ -143,7 +143,7 @@ def inaturalist_user_server_empty(mocked_responses):
 
 @pytest.fixture
 def pg_database():
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/kobotoolbox/tests/conftest.py
+++ b/f/connectors/kobotoolbox/tests/conftest.py
@@ -163,8 +163,8 @@ def koboserver_nested(mocked_responses):
 
 @pytest.fixture
 def pg_database():
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn
-    db.stop
+    db.stop()

--- a/f/connectors/localcontexts/tests/conftest.py
+++ b/f/connectors/localcontexts/tests/conftest.py
@@ -143,8 +143,8 @@ def invalid_key_server(mocked_responses):
 @pytest.fixture
 def pg_database():
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn
-    db.stop
+    db.stop()

--- a/f/connectors/locusmap/tests/conftest.py
+++ b/f/connectors/locusmap/tests/conftest.py
@@ -5,7 +5,7 @@ import testing.postgresql
 @pytest.fixture
 def pg_database():
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/odk/tests/conftest.py
+++ b/f/connectors/odk/tests/conftest.py
@@ -130,8 +130,8 @@ def odkserver_no_submissions(mocked_responses):
 @pytest.fixture
 def pg_database():
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn
-    db.stop
+    db.stop()

--- a/f/connectors/smart/tests/conftest.py
+++ b/f/connectors/smart/tests/conftest.py
@@ -5,7 +5,7 @@ import testing.postgresql
 @pytest.fixture
 def pg_database():
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/timelapse/tests/conftest.py
+++ b/f/connectors/timelapse/tests/conftest.py
@@ -5,7 +5,7 @@ import testing.postgresql
 @pytest.fixture
 def pg_database():
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/export/download_all_data/tests/conftest.py
+++ b/f/export/download_all_data/tests/conftest.py
@@ -5,7 +5,7 @@ import testing.postgresql
 @pytest.fixture
 def pg_database():
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/export/postgres_to_file/tests/conftest.py
+++ b/f/export/postgres_to_file/tests/conftest.py
@@ -7,7 +7,7 @@ import psycopg
 @pytest.fixture
 def pg_database():
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/metrics/guardianconnector/tests/conftest.py
+++ b/f/metrics/guardianconnector/tests/conftest.py
@@ -9,7 +9,7 @@ from f.common_logic.db_operations import conninfo
 @pytest.fixture(scope="function")
 def _postgres_instance():
     """Spin up a temporary PostgreSQL instance for tests."""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = testing.postgresql.Postgresql()
     try:
         yield db
     finally:


### PR DESCRIPTION
Part 2 of 3 the other two PRs are #281 and #280

Benchmark:
[Before this PR](https://app.circleci.com/pipelines/github/ConservationMetrics/gc-scripts-hub/850/workflows/f9c13d2a-06a7-4a0c-b43e-4b3822a80de4/jobs/849) - 5m 38s 
[After this PR](https://app.circleci.com/pipelines/github/ConservationMetrics/gc-scripts-hub/853/workflows/cc09e7c9-605b-4f67-8b02-a0f9a3ca228e/jobs/852) - 3m 9s (shaves ~2m 29s off of each run)

Coincidentally the same amount of time reduced by #280 

## Goal
Low hanging fruit to increase the speed of test runs in this repo.
Before this PR we couldn't use `tox -p 2` to run two test workers in parallel.
The reason, citing GPT-5.6 Sol
> With tox -p 2, two environments may each try to start PostgreSQL simultaneously, and one fails with “address already in use.”
> This branch changes it to:
> testing.postgresql.Postgresql()
> When no port is supplied, testing.postgresql chooses an available port automatically. Each test’s DSN then contains its own port, so concurrent PostgreSQL instances do not collide.

This will create merge conflicts with with changes in #281 , but I separated them to make sure we have a benchmark comparison.

## Screenshots
No visual changes

## What I changed and why
Remove port hardcoding from `testing.postgresql.Postgresql()`

## How I convinced myself this is right
Passing tests

## What I'm not doing here
Touching runtime code

## LLM use disclosure
GPT-5.6 Sol and Terra