### PR TITLE
Test speedup #3 - Remove delay after PostgreSQL mapping writes

### DIFF
--- a/f/common_logic/db_operations.py
+++ b/f/common_logic/db_operations.py
@@ -7,7 +7,6 @@ This module provides functions and classes for interacting with PostgreSQL datab
 
 import json
 import logging
-import time
 
 from psycopg import Error, connect, errors, sql
 
@@ -719,7 +718,6 @@ class StructuredDBWriter:
                 self._create_missing_mappings(
                     pgconn, columns_table_name, missing_mappings
                 )
-                time.sleep(10)
 
             inserted_count = 0
             updated_count = 0


### PR DESCRIPTION
Part 3 of 3 the other two PRs are #281 and #279 

Note, this one touches runtime code that I am not familiar with yet.

My understanding is based on this conversation (use the nav on the left to see my follow-up questions)
https://opncd.ai/share/n5HdvkkQ

So the super short summary is;
- was ported from older dagster code
- later on, we changed the db connection to to 'autocommit=True'
- this sleep was probably necessary only in the old code, where statements were not committed synchronously.

Benchmark:
[Before this PR](https://app.circleci.com/pipelines/github/ConservationMetrics/gc-scripts-hub/850/workflows/f9c13d2a-06a7-4a0c-b43e-4b3822a80de4/jobs/849) - 5m 38s 
[After this PR](https://app.circleci.com/pipelines/github/ConservationMetrics/gc-scripts-hub/852/workflows/106bccf6-b39d-4436-abaa-c1607481e92b/jobs/851) - 3m 9s (shaves ~2m 29s off of each run)

## Goal
Low hanging fruit to increase the speed of test runs in this repo.

## LLM use disclosure
GPT-5.6 Sol and Terra