### PR TITLE
Test speedup #1 - Cache initialized PostgreSQL databases in tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+@pytest.fixture(scope="session")
+def postgresql_factory():
+    import testing.postgresql
+
+    factory = testing.postgresql.PostgresqlFactory(
+        cache_initialized_db=True, port=7654
+    )
+    try:
+        yield factory
+    finally:
+        factory.clear_cache()

--- a/f/common_logic/tests/conftest.py
+++ b/f/common_logic/tests/conftest.py
@@ -3,15 +3,14 @@ import zipfile
 from pathlib import Path
 
 import pytest
-import testing.postgresql
 
 from f.common_logic.db_operations import conninfo
 
 
 @pytest.fixture(scope="function")
-def _postgres_instance():
+def _postgres_instance(postgresql_factory):
     """Spin up a temporary PostgreSQL instance for tests."""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = postgresql_factory()
     try:
         yield db
     finally:

--- a/f/connectors/alerts/tests/conftest.py
+++ b/f/connectors/alerts/tests/conftest.py
@@ -1,15 +1,14 @@
 import os
 
 import pytest
-import testing.postgresql
 from google.auth.credentials import AnonymousCredentials
 from google.cloud import storage
 
 
 @pytest.fixture
-def pg_database():
+def pg_database(postgresql_factory):
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = postgresql_factory()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/auditor2/tests/conftest.py
+++ b/f/connectors/auditor2/tests/conftest.py
@@ -1,11 +1,10 @@
 import pytest
-import testing.postgresql
 
 
 @pytest.fixture
-def pg_database():
+def pg_database(postgresql_factory):
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = postgresql_factory()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/comapeo/tests/conftest.py
+++ b/f/connectors/comapeo/tests/conftest.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import pytest
 import responses
-import testing.postgresql
 
 from f.connectors.comapeo.comapeo_pull import comapeo_server
 from f.connectors.comapeo.tests.assets import server_responses
@@ -242,8 +241,8 @@ def comapeoserver_with_failing_attachments(mocked_responses):
 
 
 @pytest.fixture
-def pg_database():
-    db = testing.postgresql.Postgresql(port=7654)
+def pg_database(postgresql_factory):
+    db = postgresql_factory()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/csv/tests/conftest.py
+++ b/f/connectors/csv/tests/conftest.py
@@ -1,11 +1,10 @@
 import pytest
-import testing.postgresql
 
 
 @pytest.fixture
-def pg_database():
+def pg_database(postgresql_factory):
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = postgresql_factory()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/earthindex/tests/conftest.py
+++ b/f/connectors/earthindex/tests/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 import responses
-import testing.postgresql
 
 from f.connectors.earthindex.earthindex_pull import BASE_URL
 from f.connectors.earthindex.tests.assets import server_responses
@@ -50,8 +49,8 @@ def earthindex_server_no_layers(mocked_responses):
 
 
 @pytest.fixture
-def pg_database():
-    db = testing.postgresql.Postgresql(port=7654)
+def pg_database(postgresql_factory):
+    db = postgresql_factory()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/epicollect/tests/conftest.py
+++ b/f/connectors/epicollect/tests/conftest.py
@@ -6,7 +6,6 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 import responses
-import testing.postgresql
 
 from f.connectors.epicollect.tests.assets import server_responses
 
@@ -177,8 +176,8 @@ def epicollect_public_server(mocked_responses):
 
 
 @pytest.fixture
-def pg_database():
-    db = testing.postgresql.Postgresql(port=7654)
+def pg_database(postgresql_factory):
+    db = postgresql_factory()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/globalforestwatch/tests/conftest.py
+++ b/f/connectors/globalforestwatch/tests/conftest.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 
 import pytest
 import responses
-import testing.postgresql
 
 from f.connectors.globalforestwatch.tests.assets import server_responses
 
@@ -38,9 +37,9 @@ def gfw_server(mocked_responses):
 
 
 @pytest.fixture
-def pg_database():
+def pg_database(postgresql_factory):
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = postgresql_factory()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/inaturalist/tests/conftest.py
+++ b/f/connectors/inaturalist/tests/conftest.py
@@ -5,7 +5,6 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 import responses
-import testing.postgresql
 
 from f.connectors.inaturalist.inaturalist_pull import BASE_URL
 from f.connectors.inaturalist.tests.assets import server_responses
@@ -142,8 +141,8 @@ def inaturalist_user_server_empty(mocked_responses):
 
 
 @pytest.fixture
-def pg_database():
-    db = testing.postgresql.Postgresql(port=7654)
+def pg_database(postgresql_factory):
+    db = postgresql_factory()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/kobotoolbox/tests/conftest.py
+++ b/f/connectors/kobotoolbox/tests/conftest.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 
 import pytest
 import responses
-import testing.postgresql
 
 from f.connectors.kobotoolbox.tests.assets import server_responses
 
@@ -162,8 +161,8 @@ def koboserver_nested(mocked_responses):
 
 
 @pytest.fixture
-def pg_database():
-    db = testing.postgresql.Postgresql(port=7654)
+def pg_database(postgresql_factory):
+    db = postgresql_factory()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/localcontexts/tests/conftest.py
+++ b/f/connectors/localcontexts/tests/conftest.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 
 import pytest
 import responses
-import testing.postgresql
 
 from f.connectors.localcontexts.tests.assets import server_responses
 
@@ -141,9 +140,9 @@ def invalid_key_server(mocked_responses):
 
 
 @pytest.fixture
-def pg_database():
+def pg_database(postgresql_factory):
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = postgresql_factory()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/locusmap/tests/conftest.py
+++ b/f/connectors/locusmap/tests/conftest.py
@@ -1,11 +1,10 @@
 import pytest
-import testing.postgresql
 
 
 @pytest.fixture
-def pg_database():
+def pg_database(postgresql_factory):
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = postgresql_factory()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/odk/tests/conftest.py
+++ b/f/connectors/odk/tests/conftest.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 import responses
-import testing.postgresql
 
 
 @pytest.fixture(autouse=True)
@@ -128,9 +127,9 @@ def odkserver_no_submissions(mocked_responses):
 
 
 @pytest.fixture
-def pg_database():
+def pg_database(postgresql_factory):
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = postgresql_factory()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/smart/tests/conftest.py
+++ b/f/connectors/smart/tests/conftest.py
@@ -1,11 +1,10 @@
 import pytest
-import testing.postgresql
 
 
 @pytest.fixture
-def pg_database():
+def pg_database(postgresql_factory):
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = postgresql_factory()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/connectors/timelapse/tests/conftest.py
+++ b/f/connectors/timelapse/tests/conftest.py
@@ -1,11 +1,10 @@
 import pytest
-import testing.postgresql
 
 
 @pytest.fixture
-def pg_database():
+def pg_database(postgresql_factory):
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = postgresql_factory()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/export/postgres_to_file/tests/conftest.py
+++ b/f/export/postgres_to_file/tests/conftest.py
@@ -1,13 +1,12 @@
 import pytest
-import testing.postgresql
 
 import psycopg
 
 
 @pytest.fixture
-def pg_database():
+def pg_database(postgresql_factory):
     """A dsn that may be used to connect to a live (local for test) postgresql server"""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = postgresql_factory()
     dsn = db.dsn()
     dsn["dbname"] = dsn.pop("database")
     yield dsn

--- a/f/metrics/guardianconnector/tests/conftest.py
+++ b/f/metrics/guardianconnector/tests/conftest.py
@@ -1,15 +1,14 @@
 import psycopg
 import pytest
 import responses
-import testing.postgresql
 
 from f.common_logic.db_operations import conninfo
 
 
 @pytest.fixture(scope="function")
-def _postgres_instance():
+def _postgres_instance(postgresql_factory):
     """Spin up a temporary PostgreSQL instance for tests."""
-    db = testing.postgresql.Postgresql(port=7654)
+    db = postgresql_factory()
     try:
         yield db
     finally:


### PR DESCRIPTION
Part 1 of 3 - the other two PRs are #279 and  #280 

Benchmark:
[Before this PR](https://app.circleci.com/pipelines/github/ConservationMetrics/gc-scripts-hub/850/workflows/f9c13d2a-06a7-4a0c-b43e-4b3822a80de4/jobs/849) - 5m 38s 
[After this PR](https://app.circleci.com/pipelines/github/ConservationMetrics/gc-scripts-hub/851/workflows/35a43c17-bf70-436a-8141-f6413be83dbe/jobs/850) - 4m 49s (shaves ~49s off of each run)

## Goal
Low hanging fruit to increase the speed of test runs in this repo.

Before this PR, tests were invoking postgresql.Postgresql() directly.
Apparently, this is invoking postgres `initdb` under the hood, which is expensive because it creates an entire PostgreSQL cluster, when all we need is an empty db for the test block

After this PR, each test now relies on PostgresqlFactory, which lets us init once as a template, and reuse it to copy and start a new postgres server/process for each test.

The parent fixture that invokes the factory is responsible for cleanup (db.stop()). Note: Many tests are **not properly invoking stop()** (they were referencing it as `db.stop` instead of invoking it). These will get fixed in #279 

## Screenshots
No visual changes

## What I changed and why
See above

## How I convinced myself this is right
Passing tests

## What I'm not doing here
No runtime changes

## LLM use disclosure
GPT-5.6 Sol and Terra